### PR TITLE
[BE] refactor(#38): User Entity 다중 필드(platformId, platformType)에 유니크 제약조건 걸기

### DIFF
--- a/backend/src/main/java/com/example/backend/auth/api/service/auth/AuthService.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/auth/AuthService.java
@@ -50,7 +50,6 @@ public class AuthService {
                             .platformType(loginResponse.getPlatformType())
                             .role(UserRole.UNAUTH)
                             .name(name)
-                            .email(email)
                             .profileImageUrl(profileImageUrl)
                             .build();
 

--- a/backend/src/main/java/com/example/backend/auth/api/service/auth/AuthService.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/auth/AuthService.java
@@ -35,7 +35,7 @@ public class AuthService {
         OAuthResponse loginResponse = oAuthService.login(platformType, code, state);
         String name = loginResponse.getName();
         String profileImageUrl = loginResponse.getProfileImageUrl();
-        String email = loginResponse.getEmail();
+        String platformId = loginResponse.getPlatformId();
 
         log.info(">>>> [ {}님이 로그인하셨습니다 ] <<<<", name);
 
@@ -43,10 +43,10 @@ public class AuthService {
          * OAuth 로그인 인증을 마쳤으니 우리 애플리케이션의 DB에도 존재하는 사용자인지 확인한다.
          * 회원이 아닐 경우, 즉 회원가입이 필요한 신규 사용자의 경우 OAuthResponse를 바탕으로 DB에 등록해준다.
          */
-        User findUser = userRepository.findByEmail(email)
+        User findUser = userRepository.findByPlatformIdAndPlatformType(platformId, platformType)
                 .orElseGet(() -> {
                     User saveUser = User.builder()
-                            .platformId(loginResponse.getPlatformId())
+                            .platformId(platformId)
                             .platformType(loginResponse.getPlatformType())
                             .role(UserRole.UNAUTH)
                             .name(name)

--- a/backend/src/main/java/com/example/backend/auth/api/service/jwt/JwtService.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/jwt/JwtService.java
@@ -33,7 +33,7 @@ public class JwtService {
     public String generateAccessToken(Map<String, String> customClaims, UserDetails userDetails, Date expiredTime) {
         return Jwts.builder()
                 .setClaims(customClaims)
-                .setSubject(userDetails.getUsername())  // 메서드명만 Username으로 우리 프로젝트에선 식별자인 email에 해당
+                .setSubject(userDetails.getUsername())  // User의 식별자
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(expiredTime)
                 .signWith(getSignInkey(), SignatureAlgorithm.HS256)

--- a/backend/src/main/java/com/example/backend/auth/api/service/oauth/adapter/github/GithubAdapter.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/oauth/adapter/github/GithubAdapter.java
@@ -48,7 +48,6 @@ public class GithubAdapter implements OAuthAdapter {
             return OAuthResponse.builder()
                     .platformId(profile.getId().toString())
                     .platformType(GITHUB)
-                    .email(profile.getEmail())
                     .name(profile.getLogin())
                     .profileImageUrl(profile.getAvatar_url())
                     .build();

--- a/backend/src/main/java/com/example/backend/auth/api/service/oauth/response/OAuthResponse.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/oauth/response/OAuthResponse.java
@@ -10,15 +10,13 @@ import lombok.NoArgsConstructor;
 public class OAuthResponse {
     private String platformId;
     private UserPlatformType platformType;
-    private String email;
     private String name;
     private String profileImageUrl;
 
     @Builder
-    public OAuthResponse(String platformId, UserPlatformType platformType, String email, String name, String profileImageUrl) {
+    public OAuthResponse(String platformId, UserPlatformType platformType, String name, String profileImageUrl) {
         this.platformId = platformId;
         this.platformType = platformType;
-        this.email = email;
         this.name = name;
         this.profileImageUrl = profileImageUrl;
     }

--- a/backend/src/main/java/com/example/backend/common/exception/ExceptionMessage.java
+++ b/backend/src/main/java/com/example/backend/common/exception/ExceptionMessage.java
@@ -12,11 +12,8 @@ public enum ExceptionMessage {
     JWT_MALFORMED("올바른 JWT 토큰의 형태가 아닙니다."),
     JWT_SIGNATURE("올바른 SIGNATURE가 아닙니다."),
     JWT_ILLEGAL_ARGUMENT("JWT 토큰의 구성 요소가 올바르지 않습니다."),
-    JWT_EMAIL_IS_NULL("해당 JWT 토큰의 식별자인 email이 null입니다."),
+    JWT_SUBJECT_IS_NULL("해당 JWT 토큰의 식별자가 null입니다."),
     JWT_INVALID_HEADER("Header의 형식이 올바르지 않습니다."),
-
-    // SecurityException
-    SECURITY_USER_NOT_FOUND("해당 email을 가진 사용자를 찾을 수 없습니다."),
 
     // OAuthException
     OAUTH_INVALID_TOKEN_URL("token URL이 올바르지 않습니다."),

--- a/backend/src/main/java/com/example/backend/domain/define/user/User.java
+++ b/backend/src/main/java/com/example/backend/domain/define/user/User.java
@@ -18,6 +18,12 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)              // 외부에서 객체 생성 못하도록 제한
 @Entity(name = "USERS")                                         // "USER"는 예약어 출동 발생하므로 "USERS"로 설정
+@Table(name = "USERS", uniqueConstraints = {
+        @UniqueConstraint(
+                name = "PLATFORM_ID_AND_PLATFORM_TYPE_UNIQUE",
+                columnNames = {"PLATFORM_ID", "PLATFORM_TYPE"}
+        )
+})
 public class User implements UserDetails {
 
     @Id

--- a/backend/src/main/java/com/example/backend/domain/define/user/User.java
+++ b/backend/src/main/java/com/example/backend/domain/define/user/User.java
@@ -47,9 +47,6 @@ public class User implements UserDetails {
     @Column(name = "NAME")
     private String name;                                        // 이름
 
-    @Column(name = "PHONE_NUMBER", unique = true)
-    private String phoneNumber;                                 // 전화번호
-
     @Column(name = "PROFILE_IMAGE_URL")
     private String profileImageUrl;                             // 프로필 사진
 
@@ -61,14 +58,12 @@ public class User implements UserDetails {
                  UserPlatformType platformType,
                  UserRole role,
                  String name,
-                 String phoneNumber,
                  String profileImageUrl,
                  boolean pushAlarmYn) {
         this.platformId = platformId;
         this.platformType = platformType;
         this.role = role;
         this.name = name;
-        this.phoneNumber = phoneNumber;
         this.profileImageUrl = profileImageUrl;
         this.pushAlarmYn = pushAlarmYn;
     }

--- a/backend/src/main/java/com/example/backend/domain/define/user/User.java
+++ b/backend/src/main/java/com/example/backend/domain/define/user/User.java
@@ -91,7 +91,7 @@ public class User implements UserDetails {
 
     @Override
     public String getUsername() {
-        return email;
+        return platformId + "_" + platformType.name();
     }
 
     @Override

--- a/backend/src/main/java/com/example/backend/domain/define/user/User.java
+++ b/backend/src/main/java/com/example/backend/domain/define/user/User.java
@@ -41,9 +41,6 @@ public class User implements UserDetails {
     @Column(name = "NAME")
     private String name;                                        // 이름
 
-    @Column(name = "EMAIL", unique = true)
-    private String email;                                       // 이메일
-
     @Column(name = "PHONE_NUMBER", unique = true)
     private String phoneNumber;                                 // 전화번호
 
@@ -58,7 +55,6 @@ public class User implements UserDetails {
                  UserPlatformType platformType,
                  UserRole role,
                  String name,
-                 String email,
                  String phoneNumber,
                  String profileImageUrl,
                  boolean pushAlarmYn) {
@@ -66,7 +62,6 @@ public class User implements UserDetails {
         this.platformType = platformType;
         this.role = role;
         this.name = name;
-        this.email = email;
         this.phoneNumber = phoneNumber;
         this.profileImageUrl = profileImageUrl;
         this.pushAlarmYn = pushAlarmYn;

--- a/backend/src/main/java/com/example/backend/domain/define/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/define/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.example.backend.domain.define.user.repository;
 
 import com.example.backend.domain.define.user.User;
+import com.example.backend.domain.define.user.constant.UserPlatformType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +12,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // select u from user u where u.platformId = :platformId and u.platformType = :platformType
     Optional<User> findByPlatformIdAndPlatformType(String platformId, UserPlatformType platformType);
+
 }

--- a/backend/src/main/java/com/example/backend/domain/define/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/define/user/repository/UserRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    // select u from user u where u.email = :email
-    Optional<User> findByEmail(String email);
+    // select u from user u where u.platformId = :platformId and u.platformType = :platformType
+    Optional<User> findByPlatformIdAndPlatformType(String platformId, UserPlatformType platformType);
 }

--- a/backend/src/test/java/com/example/backend/auth/TestConfig.java
+++ b/backend/src/test/java/com/example/backend/auth/TestConfig.java
@@ -38,7 +38,6 @@ public class TestConfig {
                 .platformType(UserPlatformType.KAKAO)
                 .role(UserRole.USER)
                 .name("홍길동")
-                .phoneNumber("010-0000-0000")
                 .profileImageUrl("https://google.com")
                 .pushAlarmYn(true)
                 .build();

--- a/backend/src/test/java/com/example/backend/auth/TestConfig.java
+++ b/backend/src/test/java/com/example/backend/auth/TestConfig.java
@@ -38,7 +38,6 @@ public class TestConfig {
                 .platformType(UserPlatformType.KAKAO)
                 .role(UserRole.USER)
                 .name("홍길동")
-                .email("hong@kakao.com")
                 .phoneNumber("010-0000-0000")
                 .profileImageUrl("https://google.com")
                 .pushAlarmYn(true)
@@ -49,7 +48,6 @@ public class TestConfig {
         return OAuthResponse.builder()
                 .platformId("1")
                 .platformType(GITHUB)
-                .email("32183520@dankook.ac.kr")
                 .name("jusung-c")
                 .profileImageUrl("http://www.naver.com")
                 .build();

--- a/backend/src/test/java/com/example/backend/auth/api/service/jwt/JwtServiceTest.java
+++ b/backend/src/test/java/com/example/backend/auth/api/service/jwt/JwtServiceTest.java
@@ -43,7 +43,8 @@ class JwtServiceTest extends TestConfig {
         String role = savedUser.getRole().name();
         String name = savedUser.getName();
         String profileImageUrl = savedUser.getProfileImageUrl();
-        String email = savedUser.getEmail();
+
+        String expectedSubject = savedUser.getPlatformId() + "_" + savedUser.getPlatformType();
 
         HashMap<String, String> map = new HashMap<>();
         map.put("role", role);
@@ -56,7 +57,7 @@ class JwtServiceTest extends TestConfig {
 
         // then
         assertAll(
-                () -> assertThat(claims.getSubject()).isEqualTo(email),
+                () -> assertThat(claims.getSubject()).isEqualTo(expectedSubject),
                 () -> assertThat(claims.get("role")).isEqualTo(role),
                 () -> assertThat(claims.get("name")).isEqualTo(name),
                 () -> assertThat(claims.get("profileImageUrl")).isEqualTo(profileImageUrl)
@@ -71,7 +72,8 @@ class JwtServiceTest extends TestConfig {
         String role = savedUser.getRole().name();
         String name = savedUser.getName();
         String profileImageUrl = savedUser.getProfileImageUrl();
-        String email = savedUser.getEmail();
+
+        String expectedSubject = savedUser.getPlatformId() + "_" + savedUser.getPlatformType();
 
         HashMap<String, String> map = new HashMap<>();
         map.put("role", role);
@@ -83,7 +85,7 @@ class JwtServiceTest extends TestConfig {
         String subject = jwtService.extractSubject(atk);
 
         // then
-        assertThat(subject).isEqualTo(email);
+        assertThat(subject).isEqualTo(expectedSubject);
 
     }
 
@@ -117,7 +119,8 @@ class JwtServiceTest extends TestConfig {
         String role = savedUser.getRole().name();
         String name = savedUser.getName();
         String profileImageUrl = savedUser.getProfileImageUrl();
-        String email = savedUser.getEmail();
+
+        String subject = savedUser.getUsername();
 
         HashMap<String, String> map = new HashMap<>();
         map.put("role", role);
@@ -127,12 +130,12 @@ class JwtServiceTest extends TestConfig {
         // when
         String atk = jwtService.generateAccessToken(map, savedUser);
         Claims claims = jwtService.extractAllClaims(atk);
-        boolean result = jwtService.isTokenValid(atk, email);
+        boolean result = jwtService.isTokenValid(atk, subject);
 
         // then
         assertThat(result).isTrue();
         assertAll(
-                () -> assertThat(claims.getSubject()).isEqualTo(email),
+                () -> assertThat(claims.getSubject()).isEqualTo(subject),
                 () -> assertThat(claims.get("role")).isEqualTo(role),
                 () -> assertThat(claims.get("name")).isEqualTo(name),
                 () -> assertThat(claims.get("profileImageUrl")).isEqualTo(profileImageUrl)
@@ -146,8 +149,7 @@ class JwtServiceTest extends TestConfig {
         User savedUser = userRepository.save(generateUser());
         String role = savedUser.getRole().name();
         String name = savedUser.getName();
-        String profileImageUrl = savedUser.getProfileImageUrl();
-        String email = savedUser.getUsername();
+        String subject = savedUser.getUsername();
 
         HashMap<String, String> map = new HashMap<>();
         map.put("role", role);
@@ -156,7 +158,7 @@ class JwtServiceTest extends TestConfig {
 
         // when
         String atk = jwtService.generateAccessToken(map, savedUser);
-        boolean result = jwtService.isTokenValid(atk, email);
+        boolean result = jwtService.isTokenValid(atk, subject);
 
         // then
         assertThat(result).isFalse();

--- a/backend/src/test/java/com/example/backend/auth/api/service/oauth/OAuthServiceTest.java
+++ b/backend/src/test/java/com/example/backend/auth/api/service/oauth/OAuthServiceTest.java
@@ -42,6 +42,11 @@ class OAuthServiceTest extends TestConfig {
     @MockBean
     private GoogleAdapter googleAdapter;
 
+    private static final String PLATFORM_ID = "platformId";
+    private static final String PLATFORM_TYPE = "platformType";
+    private static final String NAME = "name";
+    private static final String PROFILE_IMAGE_URL = "profileImageUrl";
+
     @Test
     @DisplayName("모든 플랫폼의 로그인 페이지를 성공적으로 반환한다.")
     void allUrlBuilderSuccess() {
@@ -76,19 +81,24 @@ class OAuthServiceTest extends TestConfig {
         // given
         String code = "valid-code";
         String state = "valid-state";
+        String accessToken = "access-token";
 
         OAuthResponse response = generateOauthResponse();
 
+        String expectedPlatformId = "1";
+        String expectedName = "jusung-c";
+        String expectedProfileImageUrl = "http://www.naver.com";
+
         // when
         // when 사용시 Mockito 패키지 사용
-        when(githubAdapter.getToken(any(String.class))).thenReturn("access-token");
+        when(githubAdapter.getToken(any(String.class))).thenReturn(accessToken);
         when(githubAdapter.getProfile(any(String.class))).thenReturn(response);
         OAuthResponse profile = oAuthService.login(GITHUB, code, state);
 
         // then
         assertThat(profile)
-                .extracting("platformId", "platformType", "email", "name", "profileImageUrl")
-                .contains("1", GITHUB, "32183520@dankook.ac.kr", "jusung-c", "http://www.naver.com");
+                .extracting(PLATFORM_ID, PLATFORM_TYPE, NAME, PROFILE_IMAGE_URL)
+                .contains(expectedPlatformId, GITHUB, expectedName, expectedProfileImageUrl);
 
 
     }
@@ -116,7 +126,6 @@ class OAuthServiceTest extends TestConfig {
         OAuthResponse response = OAuthResponse.builder()
                 .platformId("102514823309503386675")
                 .platformType(GOOGLE)
-                .email("xw21yog@dankook.ac.kr")
                 .name("이정우")
                 .profileImageUrl("https://lh3.googleusercontent.com/a/ACg8ocLrP_GLo-fUjSmnUZedPZbbL7ifImYTnelh108XkgOx=s96-c")
                 .build();
@@ -129,8 +138,8 @@ class OAuthServiceTest extends TestConfig {
 
         // then
         assertThat(profile)
-                .extracting("platformId", "platformType", "email", "name", "profileImageUrl")
-                .contains("102514823309503386675", GOOGLE, "xw21yog@dankook.ac.kr", "이정우", "https://lh3.googleusercontent.com/a/ACg8ocLrP_GLo-fUjSmnUZedPZbbL7ifImYTnelh108XkgOx=s96-c");
+                .extracting(PLATFORM_ID, PLATFORM_TYPE, NAME, PROFILE_IMAGE_URL)
+                .contains("102514823309503386675", GOOGLE, "이정우", "https://lh3.googleusercontent.com/a/ACg8ocLrP_GLo-fUjSmnUZedPZbbL7ifImYTnelh108XkgOx=s96-c");
 
 
     }

--- a/backend/src/test/java/com/example/backend/auth/api/service/oauth/adapter/github/GithubAdapterTest.java
+++ b/backend/src/test/java/com/example/backend/auth/api/service/oauth/adapter/github/GithubAdapterTest.java
@@ -32,16 +32,21 @@ class GithubAdapterTest extends TestConfig {
     @DisplayName("github 토큰 요청 API에 정상적인 요청을 보내면, access_token이 발행된다.")
     void githubAdapterGetTokenSuccess() {
         // given
+        String expectedToken = "access-token";
+        Long platformId = 1L;
+        String profileImageUrl = "https://www.naver.com";
+        String name = "jusung-c";
+
         MockGithubTokenClients mockGithubTokenClients = new MockGithubTokenClients();
-        MockGithubProfileClients mockGithubProfileClients = new MockGithubProfileClients();
+        MockGithubProfileClients mockGithubProfileClients = new MockGithubProfileClients(platformId, profileImageUrl, name);
         GithubAdapter githubAdapter = new GithubAdapter(mockGithubTokenClients, mockGithubProfileClients);
 
         // when
         String accessToken = githubAdapter.getToken("tokenUrl");
 
         // then
-        System.out.println("accessToken = " + accessToken);
-        assertThat(accessToken).isEqualTo("access-token");
+//        System.out.println("accessToken = " + accessToken);
+        assertThat(accessToken).isEqualTo(expectedToken);
 
     }
 
@@ -64,8 +69,12 @@ class GithubAdapterTest extends TestConfig {
     @DisplayName("github 프로필 요청 API에 정상적인 요청을 보내면, 사용자 프로필이 반환된다.")
     void githubAdapterGetProfileSuccess() {
         // given
+        Long platformId = 1L;
+        String profileImageUrl = "https://www.naver.com";
+        String name = "jusung-c";
+
         MockGithubTokenClients mockGithubTokenClients = new MockGithubTokenClients();
-        MockGithubProfileClients mockGithubProfileClients = new MockGithubProfileClients();
+        MockGithubProfileClients mockGithubProfileClients = new MockGithubProfileClients(platformId, profileImageUrl, name);
         GithubAdapter githubAdapter = new GithubAdapter(mockGithubTokenClients, mockGithubProfileClients);
 
         // when
@@ -73,10 +82,9 @@ class GithubAdapterTest extends TestConfig {
 
         // then
         assertAll(
-                () -> assertThat(profile.getPlatformId()).isEqualTo("1"),
-                () -> assertThat(profile.getEmail()).isEqualTo("32183520@dankook.ac.kr"),
-                () -> assertThat(profile.getProfileImageUrl()).isEqualTo("https://www.naver.com"),
-                () -> assertThat(profile.getName()).isEqualTo("jusung-c"),
+                () -> assertThat(profile.getPlatformId()).isEqualTo(platformId.toString()),
+                () -> assertThat(profile.getProfileImageUrl()).isEqualTo(profileImageUrl),
+                () -> assertThat(profile.getName()).isEqualTo(name),
                 () -> assertThat(profile.getPlatformType()).isEqualTo(GITHUB)
         );
     }
@@ -102,14 +110,23 @@ class GithubAdapterTest extends TestConfig {
     }
 
     static class MockGithubProfileClients implements GithubProfileClients {
+        Long platformId;
+        String profileImageUrl;
+        String name;
+
+        public MockGithubProfileClients(Long platformId, String profileImageUrl, String name) {
+            this.platformId = platformId;
+            this.profileImageUrl = profileImageUrl;
+            this.name = name;
+        }
 
         @Override
         public GithubProfileResponse getProfile(String header) {
-            return new GithubProfileResponse(1L,
-                    "jusung-c",
-                    "이주성",
+            return new GithubProfileResponse(platformId,
+                    name,
+                    name,
                     "32183520@dankook.ac.kr",
-                    "https://www.naver.com",
+                    profileImageUrl,
                     "https://github.com/jusung-c");
         }
     }

--- a/backend/src/test/java/com/example/backend/auth/api/service/oauth/builder/github/GithubURLBuilderTest.java
+++ b/backend/src/test/java/com/example/backend/auth/api/service/oauth/builder/github/GithubURLBuilderTest.java
@@ -31,7 +31,7 @@ class GithubURLBuilderTest extends TestConfig {
         String authorizeURL = urlBuilder.authorize(state);
 
         // then
-        System.out.println("authorize URL : " + authorizeURL);
+//        System.out.println("authorize URL : " + authorizeURL);
         assertThat(authorizeURL).isEqualTo(authorizationUri
                 + "?response_type=code"
                 + "&client_id=" + clientId
@@ -51,7 +51,7 @@ class GithubURLBuilderTest extends TestConfig {
         String tokenURL = urlBuilder.token(code, state);
 
         // then
-        System.out.println("tokenURL : " + tokenURL);
+//        System.out.println("tokenURL : " + tokenURL);
         assertThat(tokenURL).isEqualTo(tokenUri
                 + "?grant_type=authorization_code"
                 + "&client_id=" + clientId
@@ -69,7 +69,7 @@ class GithubURLBuilderTest extends TestConfig {
         String profileURL = urlBuilder.profile();
 
         // then
-        System.out.println("profileURL : " + profileURL);
+//        System.out.println("profileURL : " + profileURL);
         assertThat(profileURL).isEqualTo(profileUri);
 
     }

--- a/backend/src/test/java/com/example/backend/auth/config/security/SecurityConfigTest.java
+++ b/backend/src/test/java/com/example/backend/auth/config/security/SecurityConfigTest.java
@@ -3,6 +3,7 @@ package com.example.backend.auth.config.security;
 import com.example.backend.auth.TestConfig;
 import com.example.backend.auth.api.service.jwt.JwtService;
 import com.example.backend.domain.define.user.User;
+import com.example.backend.domain.define.user.constant.UserPlatformType;
 import com.example.backend.domain.define.user.constant.UserRole;
 import com.example.backend.domain.define.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -28,7 +29,7 @@ class SecurityConfigTest extends TestConfig {
 
     @AfterEach
     void tearDown() {
-        userRepository.deleteAllInBatch();
+//        userRepository.deleteAllInBatch();
     }
 
     @Test
@@ -69,7 +70,7 @@ class SecurityConfigTest extends TestConfig {
         User user = User.builder()
                 .name("김민수")
                 .role(UserRole.USER)
-                .email("kimminsu@dankook.ac.kr")
+                .platformType(UserPlatformType.GITHUB)
                 .profileImageUrl("https://google.com")
                 .build();
         User savedUser = userRepository.save(user);

--- a/backend/src/test/java/com/example/backend/common/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/example/backend/common/exception/GlobalExceptionHandlerTest.java
@@ -24,12 +24,14 @@ class GlobalExceptionHandlerTest {
         BindException bindException = new BindException(new Object(), "objectName");
         bindException.addError(new FieldError("objectName", "fieldName", "rejectedValue", false, null, null, "error message"));
 
+        String expectedResponseMessage = "fieldName: error message";
+
         // when
         JsonResult result = globalExceptionHandler.bindException(bindException);
 
         // then
         assertThat(result.getResCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-        assertThat(result.getResMsg()).isEqualTo("fieldName: error message");
+        assertThat(result.getResMsg()).isEqualTo(expectedResponseMessage);
 
     }
 
@@ -41,12 +43,14 @@ class GlobalExceptionHandlerTest {
         bindingResult.addError(new FieldError("objectName", "fieldName", "rejectedValue", false, null, null, "error message"));
         MethodArgumentNotValidException error = new MethodArgumentNotValidException(null, bindingResult);
 
+        String expectedResponseMessage = "fieldName: error message";
+
         // when
         JsonResult result = globalExceptionHandler.handleMethodArgumentNotValid(error);
 
         // then
         assertThat(result.getResCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-        assertThat(result.getResMsg()).isEqualTo("fieldName: error message");
+        assertThat(result.getResMsg()).isEqualTo(expectedResponseMessage);
 
     }
 
@@ -61,6 +65,6 @@ class GlobalExceptionHandlerTest {
 
         // then
         assertThat(result.getResCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-        assertThat(result.getResMsg()).isEqualTo("올바른 JWT 토큰의 형태가 아닙니다.");
+        assertThat(result.getResMsg()).isEqualTo(ExceptionMessage.JWT_MALFORMED.getText());
     }
 }

--- a/backend/src/test/java/com/example/backend/domain/define/user/repository/UserRepositoryTest.java
+++ b/backend/src/test/java/com/example/backend/domain/define/user/repository/UserRepositoryTest.java
@@ -19,16 +19,18 @@ class UserRepositoryTest extends TestConfig {
     }
 
     @Test
-    @DisplayName("email 정보를 이용해 해당 User를 조회할 수 있다.")
-    void findByEmailSuccess() {
+    @DisplayName("platformId와 platformType을 이용해 해당 User를 조회할 수 있다.")
+    void findByPlatformIdAndPlatformTypeTest() {
         // given
         User savedUser = userRepository.save(generateUser());
+        String subject = savedUser.getUsername();
 
         // when
-        String email = userRepository.findByEmail(savedUser.getEmail()).get().getEmail();
+        User findUser = userRepository.findByPlatformIdAndPlatformType(savedUser.getPlatformId(), savedUser.getPlatformType()).get();
 
         // then
-        assertThat(savedUser.getEmail()).isEqualTo(email);
+        assertThat(findUser).isNotNull();
+        assertThat(subject).isEqualTo(findUser.getUsername());
 
     }
 

--- a/backend/src/test/java/com/example/backend/external/clients/oauth/github/GithubClientTest.java
+++ b/backend/src/test/java/com/example/backend/external/clients/oauth/github/GithubClientTest.java
@@ -45,12 +45,10 @@ public class GithubClientTest extends TestConfig {
 /*        GithubProfileResponse profile = githubProfileClients.getProfile("Bearer " + accessToken);
 
         System.out.println("login = " + profile.getLogin());
-        System.out.println("email = " + profile.getEmail());
         System.out.println("name = " + profile.getName());
 
         assertAll(
                 () -> assertThat(profile.getLogin()).isEqualTo("jusung-c"),
-                () -> assertThat(profile.getEmail()).isEqualTo("anaooauc1236@naver.com"),
                 () -> assertThat(profile.getName()).isEqualTo("이주성")
         );*/
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#38 

### Pull Request Type

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [x]  테스트 추가, 테스트 리팩토링
- [ ]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용

- User Entity email, phoneNumber 필드 삭제
- User Entity 다중 필드(platformId, platformType)에 유니크 제약조건 걸기
- 시큐리티 식별자인 User의 getUsername()을 email에서 platformId + "_" + platformType로 변경
- 유니크 제약조건 테스트


## 💬 리뷰 요구사항

email 필드를 제거하면서 시큐리티의 식별자인 getUsername()의 반환값을 platformId + "_" + platformType으로 변경했는데요. getUsername()이 저희 주요 필터인 JWT 필터 외의 다른 필터에서도 사용되는 것 같습니다. 그래서 Security Context에 넣어줄 Authentication 객체를 만들 때 기존에 하던 방법처럼 claims 정보만으로 UserDetails를 생성하면 이후의 필터에서 getUsername() 사용시 NullPointerException이 발생해요. 일단은 그냥 Subject에서 값들을 추출해 넣어줬는데 이렇게 하는 게 맞는지 잘 모르겠어요 😥
