### PR TITLE
[BE] Feat(#65):  회원가입 및 탈퇴 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/auth/api/controller/auth/AuthController.java
+++ b/backend/src/main/java/com/example/backend/auth/api/controller/auth/AuthController.java
@@ -12,6 +12,7 @@ import com.example.backend.auth.api.service.state.LoginStateService;
 import com.example.backend.common.exception.ExceptionMessage;
 import com.example.backend.common.exception.oauth.OAuthException;
 import com.example.backend.common.response.JsonResult;
+import com.example.backend.domain.define.account.user.User;
 import com.example.backend.domain.define.account.user.constant.UserPlatformType;
 
 import io.swagger.v3.oas.annotations.media.Content;
@@ -22,6 +23,7 @@ import jakarta.security.auth.message.AuthException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Arrays;
@@ -105,4 +107,10 @@ public class AuthController {
         return JsonResult.successOf(registerResponse);
     }
 
+    @PostMapping("/delete")
+    public JsonResult<?> userDelete(@AuthenticationPrincipal User user) {
+        authService.userDelete(user.getUsername());
+
+        return JsonResult.successOf();
+    }
 }

--- a/backend/src/main/java/com/example/backend/auth/api/controller/auth/AuthController.java
+++ b/backend/src/main/java/com/example/backend/auth/api/controller/auth/AuthController.java
@@ -1,9 +1,12 @@
 package com.example.backend.auth.api.controller.auth;
 
+import com.example.backend.auth.api.controller.auth.request.AuthRegisterRequest;
 import com.example.backend.auth.api.controller.auth.response.AuthLoginPageResponse;
 import com.example.backend.auth.api.controller.auth.response.AuthLoginResponse;
 import com.example.backend.auth.api.controller.auth.response.ReissueAccessTokenResponse;
 import com.example.backend.auth.api.service.auth.AuthService;
+import com.example.backend.auth.api.service.auth.request.AuthServiceRegisterRequest;
+import com.example.backend.auth.api.service.auth.response.AuthServiceLoginResponse;
 import com.example.backend.auth.api.service.oauth.OAuthService;
 import com.example.backend.auth.api.service.state.LoginStateService;
 import com.example.backend.common.exception.ExceptionMessage;
@@ -15,6 +18,8 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
+import jakarta.security.auth.message.AuthException;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -90,4 +95,14 @@ public class AuthController {
             return JsonResult.failOf(ExceptionMessage.JWT_INVALID_HEADER.getText());
         }
     }
+    @ApiResponse(responseCode = "200", description = "회원가입 성공", content = @Content(schema = @Schema(implementation = AuthServiceLoginResponse.class)))
+    @PostMapping("/register")
+    public JsonResult<?> register(
+            @Valid @RequestBody AuthRegisterRequest request) throws AuthException {
+
+        AuthServiceLoginResponse registerResponse = authService.register(AuthServiceRegisterRequest.of(request));
+
+        return JsonResult.successOf(registerResponse);
+    }
+
 }

--- a/backend/src/main/java/com/example/backend/auth/api/controller/auth/request/AuthRegisterRequest.java
+++ b/backend/src/main/java/com/example/backend/auth/api/controller/auth/request/AuthRegisterRequest.java
@@ -1,0 +1,39 @@
+package com.example.backend.auth.api.controller.auth.request;
+
+import com.example.backend.domain.define.account.user.constant.UserPlatformType;
+import com.example.backend.domain.define.account.user.constant.UserRole;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthRegisterRequest {
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    @JsonProperty("role")
+    private UserRole role;
+
+    @NotNull
+    @JsonProperty("platformId")
+    private String platformId;
+
+    @Enumerated(EnumType.STRING)
+    @JsonProperty("platformType")
+    private UserPlatformType platformType;
+
+    @NotNull
+    @Email
+    @JsonProperty("githubEmail")
+    private String githubEmail;
+
+}

--- a/backend/src/main/java/com/example/backend/auth/api/controller/auth/request/AuthRegisterRequest.java
+++ b/backend/src/main/java/com/example/backend/auth/api/controller/auth/request/AuthRegisterRequest.java
@@ -32,8 +32,12 @@ public class AuthRegisterRequest {
     private UserPlatformType platformType;
 
     @NotNull
+    @JsonProperty("name")
+    private String name;
+
+    @NotNull
     @Email
-    @JsonProperty("githubEmail")
-    private String githubEmail;
+    @JsonProperty("githubId")
+    private String githubId;
 
 }

--- a/backend/src/main/java/com/example/backend/auth/api/service/auth/AuthService.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/auth/AuthService.java
@@ -149,7 +149,7 @@ public class AuthService {
         }
 
         // 회원가입 정보 DB 반영
-        findUser.updateRegister(request.getRole(), request.getPlatformId(), request.getPlatformType());
+        findUser.updateRegister(request.getRole(), request.getName(), request.getGithubId());
 
         // JWT Access Token, Refresh Token 재발급
         JwtToken tokens = createJwtToken(findUser);

--- a/backend/src/main/java/com/example/backend/auth/api/service/auth/AuthService.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/auth/AuthService.java
@@ -2,10 +2,13 @@ package com.example.backend.auth.api.service.auth;
 
 import com.example.backend.auth.api.controller.auth.response.AuthLoginResponse;
 import com.example.backend.auth.api.controller.auth.response.ReissueAccessTokenResponse;
+import com.example.backend.auth.api.service.auth.request.AuthServiceRegisterRequest;
+import com.example.backend.auth.api.service.auth.response.AuthServiceLoginResponse;
 import com.example.backend.auth.api.service.jwt.JwtService;
 import com.example.backend.auth.api.service.jwt.JwtToken;
 import com.example.backend.auth.api.service.oauth.OAuthService;
 import com.example.backend.auth.api.service.oauth.response.OAuthResponse;
+import com.example.backend.common.exception.auth.AuthException;
 import com.example.backend.domain.define.account.user.User;
 import com.example.backend.domain.define.account.user.constant.UserPlatformType;
 import com.example.backend.domain.define.account.user.constant.UserRole;
@@ -131,4 +134,58 @@ public class AuthService {
         }
     }
 
+    @Transactional
+    public AuthServiceLoginResponse register(AuthServiceRegisterRequest request) {
+        User findUser = userRepository.findByPlatformIdAndPlatformType(request.getPlatformId(),request.getPlatformType()).orElseThrow(() -> {
+            // UNAUTH인 토큰을 받고 회원 탈퇴 후 그 토큰으로 회원가입 요청시 예외 처리
+            log.warn(">>>> User Not Exist : {}", ExceptionMessage.AUTH_INVALID_REGISTER.getText());
+            throw new AuthException(ExceptionMessage.AUTH_INVALID_REGISTER);
+        });
+
+        // UNAUTH 토큰으로 회원가입을 요청했지만 이미 update되어 UNAUTH가 아닌 사용자 예외 처리
+        if (findUser.getRole() != UserRole.UNAUTH) {
+            log.warn(">>>> Not UNAUTH User : {}", ExceptionMessage.AUTH_DUPLICATE_UNAUTH_REGISTER.getText());
+            throw new AuthException(ExceptionMessage.AUTH_DUPLICATE_UNAUTH_REGISTER);
+        }
+
+        // 회원가입 정보 DB 반영
+        findUser.updateRegister(request.getRole(), request.getPlatformId(), request.getPlatformType());
+
+        // JWT Access Token, Refresh Token 재발급
+        JwtToken tokens = createJwtToken(findUser);
+
+        return AuthServiceLoginResponse.builder()
+                .accessToken(tokens.getAccessToken())
+                .refreshToken(tokens.getRefreshToken())
+                .role(findUser.getRole())
+                .build();
+    }
+
+    private JwtToken createJwtToken(User user) {
+        // JWT 토큰 생성을 위한 claims 생성
+        HashMap<String, String> claims = new HashMap<>();
+        claims.put(ROLE_CLAIM, user.getRole().name());
+        claims.put(PLATFORM_ID_CLAIM, user.getPlatformId());
+        claims.put(PLATFORM_TYPE_CLAIM, String.valueOf(user.getPlatformType()));
+
+        // Access Token 생성
+        final String accessToken = jwtService.generateAccessToken(claims, user);
+        // Refresh Token 생성
+        final String refreshToken = jwtService.generateRefreshToken(claims, user);
+
+        log.info(">>>> {} generate Tokens", user.getName());
+
+        // Refresh Token 저장 - REDIS
+        RefreshToken rt = RefreshToken.builder()
+                .refreshToken(refreshToken)
+                .subject(user.getUsername())
+                .build();
+        refreshTokenService.saveRefreshToken(rt);
+
+
+        return JwtToken.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
 }

--- a/backend/src/main/java/com/example/backend/auth/api/service/auth/AuthService.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/auth/AuthService.java
@@ -188,4 +188,26 @@ public class AuthService {
                 .refreshToken(refreshToken)
                 .build();
     }
+    @Transactional
+    public void userDelete(String userName) {
+        String[] platformIdAndPlatformType = extractFromSubject(userName);
+        String platformId = platformIdAndPlatformType[0];
+        String platformType = platformIdAndPlatformType[1];
+        User user = userRepository.findByPlatformIdAndPlatformType(platformId, UserPlatformType.KAKAO.valueOf(platformType)).orElseThrow(() -> {
+            log.warn(">>>> User Delete Fail : {}", ExceptionMessage.AUTH_NOT_FOUND.getText());
+            throw new AuthException(ExceptionMessage.AUTH_NOT_FOUND);
+        });
+
+        try {
+            user.deleteUser();
+            log.info(">>>> {} Info is Deleted.", user.getName());
+        } catch (IllegalArgumentException e) {
+            log.error(">>>> ID = {} : 계정 삭제에 실패했습니다.", user.getId());
+            throw new AuthException(ExceptionMessage.AUTH_DELETE_FAIL);
+        }
+    }
+    private String[] extractFromSubject(String subject) {
+        // "_"로 문자열을 나누고 id와 type을 추출
+        return subject.split("_");
+    }
 }

--- a/backend/src/main/java/com/example/backend/auth/api/service/auth/request/AuthServiceRegisterRequest.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/auth/request/AuthServiceRegisterRequest.java
@@ -1,0 +1,29 @@
+package com.example.backend.auth.api.service.auth.request;
+
+
+import com.example.backend.auth.api.controller.auth.request.AuthRegisterRequest;
+import com.example.backend.domain.define.account.user.constant.UserPlatformType;
+import com.example.backend.domain.define.account.user.constant.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthServiceRegisterRequest {
+    private UserRole role;
+    private String platformId;
+    private UserPlatformType platformType;
+    private String githubEmail;
+    public static AuthServiceRegisterRequest of(AuthRegisterRequest request) {
+        return AuthServiceRegisterRequest.builder()
+                .role(request.getRole())
+                .platformId(request.getPlatformId())
+                .platformType(request.getPlatformType())
+                .githubEmail(request.getGithubEmail())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/example/backend/auth/api/service/auth/request/AuthServiceRegisterRequest.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/auth/request/AuthServiceRegisterRequest.java
@@ -17,13 +17,15 @@ public class AuthServiceRegisterRequest {
     private UserRole role;
     private String platformId;
     private UserPlatformType platformType;
-    private String githubEmail;
+    private String name;
+    private String githubId;
     public static AuthServiceRegisterRequest of(AuthRegisterRequest request) {
         return AuthServiceRegisterRequest.builder()
                 .role(request.getRole())
                 .platformId(request.getPlatformId())
                 .platformType(request.getPlatformType())
-                .githubEmail(request.getGithubEmail())
+                .name(request.getName())
+                .githubId(request.getGithubId())
                 .build();
     }
 }

--- a/backend/src/main/java/com/example/backend/auth/api/service/auth/response/AuthServiceLoginResponse.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/auth/response/AuthServiceLoginResponse.java
@@ -1,0 +1,19 @@
+package com.example.backend.auth.api.service.auth.response;
+
+import com.example.backend.domain.define.account.user.constant.UserRole;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AuthServiceLoginResponse {
+    private String accessToken;
+    private String refreshToken;
+    private UserRole role;
+
+    @Builder
+    public AuthServiceLoginResponse(String accessToken, String refreshToken, UserRole role) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.role = role;
+    }
+}

--- a/backend/src/main/java/com/example/backend/common/exception/ExceptionMessage.java
+++ b/backend/src/main/java/com/example/backend/common/exception/ExceptionMessage.java
@@ -30,9 +30,11 @@ public enum ExceptionMessage {
     // LoginState
     LOGINSTATE_IS_NOT_USE("해당 LoginState를 사용할 수 없습니다."),
     LOGINSTATE_INVALID_VALUE("LoginState 정보가 잘못되었습니다."),
-    LOGINSTATE_NOT_FOUND("LoginState를 찾을 수 없습니다.")
+    LOGINSTATE_NOT_FOUND("LoginState를 찾을 수 없습니다."),
 
-
+    // AuthException
+    AUTH_INVALID_REGISTER("잘못된 회원가입 요청입니다."),
+    AUTH_DUPLICATE_UNAUTH_REGISTER("중복된 회원가입 요청입니다."),
     ;
     private final String text;
 }

--- a/backend/src/main/java/com/example/backend/common/exception/ExceptionMessage.java
+++ b/backend/src/main/java/com/example/backend/common/exception/ExceptionMessage.java
@@ -35,6 +35,8 @@ public enum ExceptionMessage {
     // AuthException
     AUTH_INVALID_REGISTER("잘못된 회원가입 요청입니다."),
     AUTH_DUPLICATE_UNAUTH_REGISTER("중복된 회원가입 요청입니다."),
+    AUTH_NOT_FOUND("계정 정보를 찾을 수 없습니다."),
+    AUTH_DELETE_FAIL("계정 삭제에 실패했습니다."),
     ;
     private final String text;
 }

--- a/backend/src/main/java/com/example/backend/common/exception/auth/AuthException.java
+++ b/backend/src/main/java/com/example/backend/common/exception/auth/AuthException.java
@@ -1,0 +1,10 @@
+package com.example.backend.common.exception.auth;
+
+import com.example.backend.common.exception.ExceptionMessage;
+import com.example.backend.common.exception.GitudyException;
+
+public class AuthException extends GitudyException {
+    public AuthException(ExceptionMessage message) {
+        super(message.getText());
+    }
+}

--- a/backend/src/main/java/com/example/backend/domain/define/account/user/User.java
+++ b/backend/src/main/java/com/example/backend/domain/define/account/user/User.java
@@ -88,7 +88,9 @@ public class User extends BaseEntity implements UserDetails {
         this.platformId = platformId;
         this.platformType = platformType;
     }
-
+    public void deleteUser() {
+        this.role = UserRole.WITHDRAW;
+    }
     // Spring Security UserDetails Area
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/backend/src/main/java/com/example/backend/domain/define/account/user/User.java
+++ b/backend/src/main/java/com/example/backend/domain/define/account/user/User.java
@@ -83,10 +83,10 @@ public class User extends BaseEntity implements UserDetails {
         this.name = name;
     }
 
-    public void updateRegister(UserRole role, String platformId, UserPlatformType platformType) {
+    public void updateRegister(UserRole role, String name, String githubId) {
         this.role = role;
-        this.platformId = platformId;
-        this.platformType = platformType;
+        this.name = name;
+        this.githubId = githubId;
     }
     public void deleteUser() {
         this.role = UserRole.WITHDRAW;

--- a/backend/src/main/java/com/example/backend/domain/define/account/user/User.java
+++ b/backend/src/main/java/com/example/backend/domain/define/account/user/User.java
@@ -83,6 +83,12 @@ public class User extends BaseEntity implements UserDetails {
         this.name = name;
     }
 
+    public void updateRegister(UserRole role, String platformId, UserPlatformType platformType) {
+        this.role = role;
+        this.platformId = platformId;
+        this.platformType = platformType;
+    }
+
     // Spring Security UserDetails Area
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/backend/src/test/java/com/example/backend/auth/api/controller/auth/AuthControllerTest.java
+++ b/backend/src/test/java/com/example/backend/auth/api/controller/auth/AuthControllerTest.java
@@ -88,8 +88,8 @@ class AuthControllerTest extends TestConfig {
 
         HashMap<String, String> map = new HashMap<>();
         map.put("role", savedUser.getRole().name());
-        map.put("name", savedUser.getName());
-        map.put("profileImageUrl", savedUser.getProfileImageUrl());
+        map.put("platformId", savedUser.getPlatformId());
+        map.put("platformType", String.valueOf(savedUser.getPlatformType()));
 
         String accessToken = jwtService.generateAccessToken(map, user);
         String refreshToken = jwtService.generateRefreshToken(map, user);
@@ -161,9 +161,8 @@ class AuthControllerTest extends TestConfig {
                 .andExpect(jsonPath("$.res_code").value(400))
                 .andExpect(jsonPath("$.res_msg").value("githubEmail: must be a well-formed email address"));
     }
-    @Test
     @DisplayName("올바른 사용자의 토큰으로 사용자 계정 탈퇴 요청을 하면, 계정이 삭제된다.")
-    void One() throws Exception {
+    void validUserTokenRequestWithDrawThenUserDelete() throws Exception {
         // given
         User user = User.builder()
                 .platformId("12345")

--- a/backend/src/test/java/com/example/backend/auth/api/controller/auth/AuthControllerTest.java
+++ b/backend/src/test/java/com/example/backend/auth/api/controller/auth/AuthControllerTest.java
@@ -126,7 +126,8 @@ class AuthControllerTest extends TestConfig {
                 .role(UserRole.USER)
                 .platformId("1234")
                 .platformType(UserPlatformType.KAKAO)
-                .githubEmail("test@1234")
+                .name("구영민")
+                .githubId("test@1234")
                 .build();
 
         mockMvc.perform(
@@ -150,7 +151,8 @@ class AuthControllerTest extends TestConfig {
                 .role(UserRole.USER) // userRole null
                 .platformId("1234")
                 .platformType(UserPlatformType.KAKAO)
-                .githubEmail("test1234") // 잘못된 형식의 email
+                .name("구영민")
+                .githubId("test1234") // 잘못된 형식의 email
                 .build();
 
         mockMvc.perform(
@@ -160,7 +162,7 @@ class AuthControllerTest extends TestConfig {
                 // .andExpect(status().isBadRequest());
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.res_code").value(400))
-                .andExpect(jsonPath("$.res_msg").value("githubEmail: must be a well-formed email address"));
+                .andExpect(jsonPath("$.res_msg").value("githubId: must be a well-formed email address"));
     }
     @Test
     @DisplayName("올바른 사용자의 토큰으로 사용자 계정 탈퇴 요청을 하면, 계정이 삭제된다.")
@@ -170,7 +172,7 @@ class AuthControllerTest extends TestConfig {
         UserPlatformType userPlatformType=UserPlatformType.KAKAO;
         String name = "구영민";
         String profileImageURL = "google.co.kr";
-        String githubEmail="1234@github.com";
+        String githubId="1234@github.com";
 
         // given
         User user = User.builder()
@@ -190,7 +192,7 @@ class AuthControllerTest extends TestConfig {
                 .role(UserRole.USER)
                 .platformId(user.getPlatformId())
                 .platformType(user.getPlatformType())
-                .githubEmail(githubEmail)
+                .githubId(githubId)
                 .build();
 
         String accessToken = jwtService.generateAccessToken(map, savedUser);

--- a/backend/src/test/java/com/example/backend/auth/api/service/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/example/backend/auth/api/service/auth/AuthServiceTest.java
@@ -14,13 +14,10 @@ import com.example.backend.domain.define.account.user.constant.UserRole;
 import com.example.backend.domain.define.account.user.repository.UserRepository;
 import io.jsonwebtoken.Claims;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 
 import static com.example.backend.domain.define.account.user.constant.UserPlatformType.GITHUB;
 import static com.example.backend.domain.define.account.user.constant.UserPlatformType.KAKAO;
@@ -28,10 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class AuthServiceTest extends TestConfig {
 
@@ -272,40 +265,5 @@ class AuthServiceTest extends TestConfig {
 
         // then
         assertThat(deletedUser.getRole()).isEqualTo(UserRole.WITHDRAW);
-    }
-
-    @Autowired
-    private MockMvc mockMvc;
-    @Test
-    @DisplayName("22222222222")
-    void Two() throws Exception {
-        // given
-        User user = User.builder()
-                .platformId("12345")
-                .platformType(UserPlatformType.KAKAO)
-                .name("구영민")
-                .profileImageUrl("google.co.kr")
-                .role(UserRole.UNAUTH)
-                .build();
-        userRepository.saveAndFlush(user);
-
-        AuthServiceRegisterRequest request = AuthServiceRegisterRequest.builder()
-                .role(UserRole.USER)
-                .platformId(user.getPlatformId())
-                .platformType(user.getPlatformType())
-                .githubEmail("1234@github.com")
-                .build();
-
-        AuthServiceLoginResponse response = authService.register(request);
-        String accessToken = response.getAccessToken();
-        String refreshToken = response.getRefreshToken();
-        // when
-        mockMvc.perform(post("/auth/delete")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header("Authorization", "Bearer " + accessToken+" "+refreshToken))
-                // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200));
-
     }
 }

--- a/backend/src/test/java/com/example/backend/auth/api/service/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/example/backend/auth/api/service/auth/AuthServiceTest.java
@@ -170,7 +170,7 @@ class AuthServiceTest extends TestConfig {
         String platformId = "1234";
         String name = "testUser";
         String profileImageUrl = "https://example.com/profile.jpg";
-        String githubEmail = "test@github.com";
+        String githubId = "test@github.com";
         // UNAUTH 사용자 저장
         User unauthUser = User.builder()
                 .role(UserRole.UNAUTH)
@@ -187,7 +187,8 @@ class AuthServiceTest extends TestConfig {
                 .role(UserRole.USER)
                 .platformId(platformId)
                 .platformType(platformType)
-                .githubEmail(githubEmail)
+                .githubId(githubId)
+                .name(name)
                 .build();
 
         // when
@@ -209,7 +210,7 @@ class AuthServiceTest extends TestConfig {
         String platformId = "1234";
         String name = "testUser";
         String profileImageUrl = "https://example.com/profile.jpg";
-        String githubEmail = "test@github.com";
+        String githubId = "test@github.com";
 
         User user = User.builder()
                 .platformId(platformId)
@@ -226,7 +227,8 @@ class AuthServiceTest extends TestConfig {
                 .role(UserRole.USER)
                 .platformId(platformId)
                 .platformType(platformType)
-                .githubEmail(githubEmail)
+                .name(name)
+                .githubId(githubId)
                 .build();
 
         // then


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#65

### Pull Request Type

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [x]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [x]  테스트 추가, 테스트 리팩토링
- [x]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용

 회원가입
- platformId, platformType 받아서 데이터베이스에 저장
- platformId, platformType와 함께 githubEmail 입력받아서 이메일 검증
- 회원가입 성공하면 JWT Access Token, Refresh Token 재발급 후 response

 회원탈퇴
- User status를 WITHDRAW로 변경

## 💬 리뷰 요구사항
아마 제가 생각 못한 부분이 많을거 같은데 리뷰 부탁드립니다~


 #### Q) [올바른 사용자의 토큰으로 사용자 계정 탈퇴 요청을 하면, 계정이 삭제된다.]  이 테스트 오류 관련하여 질문이 있습니다.
AuthControllerTest에 존재하는 [올바른 사용자의 토큰으로 사용자 계정 탈퇴 요청을 하면, 계정이 삭제된다.] 테스트는 오류가 납니다.
테스트 함수 이름만 바꿔서 AuthServiceTest에 [22222222222]라는 이름으로 똑같은 코드로 돌려보니 성공합니다.

같은 코드인데 왜 테스트 성공 유무가 다른지 모르겠습니다. (해결)

