### PR TITLE
[BE] feat(#124): 스터디 삭제 api 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/common/exception/study/StudyInfoException.java
+++ b/backend/src/main/java/com/example/backend/common/exception/study/StudyInfoException.java
@@ -1,0 +1,11 @@
+package com.example.backend.common.exception.study;
+
+import com.example.backend.common.exception.ExceptionMessage;
+import com.example.backend.common.exception.GitudyException;
+
+
+public class StudyInfoException extends GitudyException {
+    public StudyInfoException(ExceptionMessage message) {
+        super(message.getText());
+    }
+}

--- a/backend/src/main/java/com/example/backend/domain/define/study/category/info/repository/StudyCategoryRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/category/info/repository/StudyCategoryRepository.java
@@ -1,10 +1,7 @@
-package com.example.backend.study.api.service.category.info.repository;
+package com.example.backend.domain.define.study.category.info.repository;
 
 import com.example.backend.domain.define.study.category.info.StudyCategory;
-import com.example.backend.domain.define.study.member.StudyMember;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
 
 public interface StudyCategoryRepository extends JpaRepository<StudyCategory, Long> {
 }

--- a/backend/src/main/java/com/example/backend/domain/define/study/category/mapping/repository/StudyCategoryMappingRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/category/mapping/repository/StudyCategoryMappingRepository.java
@@ -1,4 +1,4 @@
-package com.example.backend.study.api.service.category.mapping.repository;
+package com.example.backend.domain.define.study.category.mapping.repository;
 
 import com.example.backend.domain.define.study.category.mapping.StudyCategoryMapping;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/backend/src/main/java/com/example/backend/domain/define/study/info/StudyInfo.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/info/StudyInfo.java
@@ -103,4 +103,7 @@ public class StudyInfo extends BaseEntity {
         }
         return sb.toString();
     }
+    public void updateDeletedStudy() {
+        this.status = StudyStatus.STUDY_DELETED;
+    }
 }

--- a/backend/src/main/java/com/example/backend/domain/define/study/member/StudyMember.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/member/StudyMember.java
@@ -49,4 +49,7 @@ public class StudyMember extends BaseEntity {
         this.status = status;
         this.score = score;
     }
+    public void updateWithdrawalStudyMember(){
+        this.status=StudyMemberStatus.STUDY_WITHDRAWAL;
+    }
 }

--- a/backend/src/main/java/com/example/backend/domain/define/study/member/repository/StudyMemberRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/member/repository/StudyMemberRepository.java
@@ -3,5 +3,8 @@ package com.example.backend.domain.define.study.member.repository;
 import com.example.backend.domain.define.study.member.StudyMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface StudyMemberRepository  extends JpaRepository<StudyMember, Long>, StudyMemberRepositoryCustom {
+    List<StudyMember> findByStudyInfoId(Long studyInfoId);
 }

--- a/backend/src/main/java/com/example/backend/study/api/controller/info/StudyInfoController.java
+++ b/backend/src/main/java/com/example/backend/study/api/controller/info/StudyInfoController.java
@@ -1,20 +1,19 @@
 package com.example.backend.study.api.controller.info;
 
 import com.example.backend.auth.api.service.auth.AuthService;
+import com.example.backend.common.exception.GitudyException;
 import com.example.backend.common.response.JsonResult;
 import com.example.backend.domain.define.account.user.User;
 import com.example.backend.study.api.controller.info.request.StudyInfoRegisterRequest;
 import com.example.backend.study.api.controller.info.response.StudyInfoRegisterResponse;
 import com.example.backend.study.api.service.info.StudyInfoService;
+import com.example.backend.study.api.service.member.StudyMemberService;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -23,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class StudyInfoController {
     private final StudyInfoService studyInfoService;
     private final AuthService authService;
-
+    private final StudyMemberService studyMemberService;
     @ApiResponse(responseCode = "200", description = "스터디 등록 성공")
     @PostMapping("/")
     public JsonResult<?> registerStudy(@AuthenticationPrincipal User user,
@@ -31,5 +30,19 @@ public class StudyInfoController {
         authService.authenticate(studyInfoRequest.getUserId(), user);
         StudyInfoRegisterResponse response = studyInfoService.registerStudy(studyInfoRequest);
         return JsonResult.successOf("Study Register Success.");
+    }
+
+    @ApiResponse(responseCode = "200", description = "스터디 삭제 성공")
+    @DeleteMapping("/{studyInfoId}")
+    public JsonResult<?> deleteStudy(@AuthenticationPrincipal User user,
+                                     @PathVariable(name = "studyInfoId") Long studyInfoId) {
+        try {
+            authService.findUserInfo(user);
+            studyInfoService.deleteStudy(user, studyInfoId);
+
+        } catch (GitudyException e) {
+            return JsonResult.failOf(e.getMessage());
+        }
+        return JsonResult.successOf("Study deleted successfully");
     }
 }

--- a/backend/src/main/java/com/example/backend/study/api/controller/info/StudyInfoController.java
+++ b/backend/src/main/java/com/example/backend/study/api/controller/info/StudyInfoController.java
@@ -37,8 +37,9 @@ public class StudyInfoController {
     public JsonResult<?> deleteStudy(@AuthenticationPrincipal User user,
                                      @PathVariable(name = "studyInfoId") Long studyInfoId) {
         try {
-            authService.findUserInfo(user);
-            studyInfoService.deleteStudy(user, studyInfoId);
+            // 유저가 스터디 장이 아닐 경우 예외 발생
+            studyMemberService.isValidateStudyLeader(user, studyInfoId);
+            studyInfoService.deleteStudy(studyInfoId);
 
         } catch (GitudyException e) {
             return JsonResult.failOf(e.getMessage());

--- a/backend/src/main/java/com/example/backend/study/api/controller/info/StudyInfoController.java
+++ b/backend/src/main/java/com/example/backend/study/api/controller/info/StudyInfoController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/studyinfo")
+@RequestMapping("/study")
 public class StudyInfoController {
     private final StudyInfoService studyInfoService;
     private final AuthService authService;

--- a/backend/src/main/java/com/example/backend/study/api/service/info/StudyInfoService.java
+++ b/backend/src/main/java/com/example/backend/study/api/service/info/StudyInfoService.java
@@ -74,8 +74,7 @@ public class StudyInfoService {
 
     private void updateWithdrawalStudyMember(Long studyInfoId) {
         List<StudyMember> studyMembers = studyMemberRepository.findByStudyInfoId(studyInfoId);
-        studyMembers.stream()
-                .forEach(StudyMember::updateWithdrawalStudyMember);
+        studyMembers.forEach(StudyMember::updateWithdrawalStudyMember);
     }
 
     // 카테고리 매핑 생성해주는 함수

--- a/backend/src/main/java/com/example/backend/study/api/service/info/StudyInfoService.java
+++ b/backend/src/main/java/com/example/backend/study/api/service/info/StudyInfoService.java
@@ -56,15 +56,12 @@ public class StudyInfoService {
 
     // 스터디 삭제
     @Transactional
-    public boolean deleteStudy(User user, Long studyInfoId) {
+    public boolean deleteStudy(Long studyInfoId) {
         // 스터디가 있는지 확인
         StudyInfo studyInfo = studyInfoRepository.findById(studyInfoId).orElseThrow(() -> {
             log.warn(">>>> {} : {} <<<<", studyInfoId, ExceptionMessage.STUDY_INFO_NOT_FOUND.getText());
             throw new StudyInfoException(ExceptionMessage.STUDY_INFO_NOT_FOUND);
         });
-
-        // 유저가 스터디 장이 아닐 경우 예외 발생
-        studyMemberService.isValidateStudyLeader(user, studyInfoId);
 
         // 스터디 상태정보 변경
         studyInfo.updateDeletedStudy();

--- a/backend/src/test/java/com/example/backend/auth/config/fixture/UserFixture.java
+++ b/backend/src/test/java/com/example/backend/auth/config/fixture/UserFixture.java
@@ -18,6 +18,16 @@ public class UserFixture {
                 .build();
     }
 
+    public static User generateAuthUserByPlatformId(String platformId) {
+        return User.builder()
+                .platformId(platformId)
+                .platformType(GITHUB)
+                .role(USER)
+                .name("이름")
+                .githubId("깃허브아이디")
+                .profileImageUrl("프로필이미지")
+                .build();
+    }
     public static User generateUNAUTHUser() {
         return User.builder()
                 .platformId("1")

--- a/backend/src/test/java/com/example/backend/study/api/controller/info/StudyInfoControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/controller/info/StudyInfoControllerTest.java
@@ -14,6 +14,7 @@ import com.example.backend.domain.define.study.info.repository.StudyInfoReposito
 import com.example.backend.study.api.controller.info.request.StudyInfoRegisterRequest;
 import com.example.backend.study.api.controller.info.response.StudyInfoRegisterResponse;
 import com.example.backend.study.api.service.info.StudyInfoService;
+import com.example.backend.study.api.service.member.StudyMemberService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.AfterEach;
@@ -33,6 +34,7 @@ import static com.example.backend.domain.define.study.StudyCategory.StudyCategor
 import static com.example.backend.domain.define.study.info.StudyInfoFixture.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -64,6 +66,8 @@ class StudyInfoControllerTest extends TestConfig {
     private StudyInfoRepository studyInfoRepository;
     @Autowired
     private StudyCategoryRepository studyCategoryRepository;
+    @MockBean
+    private StudyMemberService studyMemberService;
 
     @AfterEach
     void tearDown() {
@@ -169,7 +173,9 @@ class StudyInfoControllerTest extends TestConfig {
 
         // when
         when(authService.findUserInfo(any())).thenReturn(UserInfoResponse.of(savedUser));
-        when(studyInfoService.deleteStudy(any(), anyLong())).thenReturn(true);
+        doNothing().when(studyMemberService).isValidateStudyLeader(any(User.class), any(Long.class));
+
+        when(studyInfoService.deleteStudy(anyLong())).thenReturn(true);
 
         // then
         mockMvc.perform(delete("/studyinfo/" + studyInfo.getId())

--- a/backend/src/test/java/com/example/backend/study/api/controller/info/StudyInfoControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/controller/info/StudyInfoControllerTest.java
@@ -93,7 +93,7 @@ class StudyInfoControllerTest extends TestConfig {
         when(studyInfoService.registerStudy(any(StudyInfoRegisterRequest.class)))
                 .thenReturn(Mockito.mock(StudyInfoRegisterResponse.class));
         // then
-        mockMvc.perform(post("/studyinfo/")
+        mockMvc.perform(post("/study/")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(request)))
@@ -123,7 +123,7 @@ class StudyInfoControllerTest extends TestConfig {
         when(studyInfoService.registerStudy(any(StudyInfoRegisterRequest.class)))
                 .thenReturn(Mockito.mock(StudyInfoRegisterResponse.class));
         // then
-        mockMvc.perform(post("/studyinfo/")
+        mockMvc.perform(post("/study/")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(request)))
@@ -152,7 +152,7 @@ class StudyInfoControllerTest extends TestConfig {
         when(studyInfoService.registerStudy(any(StudyInfoRegisterRequest.class)))
                 .thenReturn(Mockito.mock(StudyInfoRegisterResponse.class));
         // then
-        mockMvc.perform(post("/studyinfo/")
+        mockMvc.perform(post("/study/")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(request)))
@@ -178,7 +178,7 @@ class StudyInfoControllerTest extends TestConfig {
         when(studyInfoService.deleteStudy(anyLong())).thenReturn(true);
 
         // then
-        mockMvc.perform(delete("/studyinfo/" + studyInfo.getId())
+        mockMvc.perform(delete("/study/" + studyInfo.getId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                 )

--- a/backend/src/test/java/com/example/backend/study/api/service/info/StudyInfoServiceTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/service/info/StudyInfoServiceTest.java
@@ -2,7 +2,6 @@ package com.example.backend.study.api.service.info;
 
 import com.example.backend.auth.TestConfig;
 import com.example.backend.auth.config.fixture.UserFixture;
-import com.example.backend.common.exception.member.MemberException;
 import com.example.backend.common.exception.study.StudyInfoException;
 import com.example.backend.domain.define.account.user.User;
 import com.example.backend.domain.define.account.user.repository.UserRepository;
@@ -129,7 +128,7 @@ class StudyInfoServiceTest extends TestConfig {
         studyMemberRepository.saveAll(studyMembers);
 
         // when
-        studyInfoService.deleteStudy(leaderUser, studyInfo.getId());
+        studyInfoService.deleteStudy(studyInfo.getId());
 
 
         // then
@@ -157,20 +156,7 @@ class StudyInfoServiceTest extends TestConfig {
 
         // then
         assertThrows(StudyInfoException.class, () -> {
-            studyInfoService.deleteStudy(user, invalidStudyInfoId);
+            studyInfoService.deleteStudy(invalidStudyInfoId);
         }, "해당 스터디정보를 찾을 수 없습니다.");
-    }
-
-    @Test
-    void 유저가_스터디장이_아닐_경우_스터디_삭제_실패_테스트() {
-        // given
-        User user = userRepository.save(UserFixture.generateAuthUser());
-        StudyInfo studyInfo = studyInfoRepository.save(generateStudyInfo(user.getId()));
-        StudyMember studyMember = studyMemberRepository.save(StudyMemberFixture.createDefaultStudyMember(user.getId(), studyInfo.getId()));
-
-        // then
-        assertThrows(MemberException.class, () -> {
-            studyInfoService.deleteStudy(user, studyInfo.getId());
-        }, "스터디장이 아닙니다.");
     }
 }

--- a/backend/src/test/java/com/example/backend/study/api/service/info/StudyInfoServiceTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/service/info/StudyInfoServiceTest.java
@@ -1,21 +1,30 @@
 package com.example.backend.study.api.service.info;
 
 import com.example.backend.auth.TestConfig;
+import com.example.backend.auth.config.fixture.UserFixture;
+import com.example.backend.common.exception.member.MemberException;
+import com.example.backend.common.exception.study.StudyInfoException;
 import com.example.backend.domain.define.account.user.User;
 import com.example.backend.domain.define.account.user.repository.UserRepository;
 import com.example.backend.domain.define.study.category.info.StudyCategory;
+import com.example.backend.domain.define.study.category.info.repository.StudyCategoryRepository;
 import com.example.backend.domain.define.study.category.mapping.StudyCategoryMapping;
+import com.example.backend.domain.define.study.category.mapping.repository.StudyCategoryMappingRepository;
+import com.example.backend.domain.define.study.info.StudyInfo;
+import com.example.backend.domain.define.study.info.constant.StudyStatus;
+import com.example.backend.domain.define.study.info.repository.StudyInfoRepository;
 import com.example.backend.domain.define.study.member.StudyMember;
+import com.example.backend.domain.define.study.member.StudyMemberFixture;
+import com.example.backend.domain.define.study.member.constant.StudyMemberStatus;
 import com.example.backend.domain.define.study.member.repository.StudyMemberRepository;
 import com.example.backend.study.api.controller.info.request.StudyInfoRegisterRequest;
 import com.example.backend.study.api.controller.info.response.StudyInfoRegisterResponse;
-import com.example.backend.study.api.service.category.info.repository.StudyCategoryRepository;
-import com.example.backend.study.api.service.category.mapping.repository.StudyCategoryMappingRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -23,7 +32,9 @@ import static com.example.backend.auth.config.fixture.UserFixture.generateAuthUs
 import static com.example.backend.domain.define.study.StudyCategory.StudyCategoryFixture.CATEGORY_SIZE;
 import static com.example.backend.domain.define.study.StudyCategory.StudyCategoryFixture.createDefaultPublicStudyCategories;
 import static com.example.backend.domain.define.study.info.StudyInfo.JOIN_CODE_LENGTH;
+import static com.example.backend.domain.define.study.info.StudyInfoFixture.generateStudyInfo;
 import static com.example.backend.domain.define.study.info.StudyInfoFixture.generateStudyInfoRegisterRequestWithCategory;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -39,6 +50,8 @@ class StudyInfoServiceTest extends TestConfig {
     private StudyMemberRepository studyMemberRepository;
     @Autowired
     private StudyCategoryRepository studyCategoryRepository;
+    @Autowired
+    private StudyInfoRepository studyInfoRepository;
 
     @AfterEach
     void tearDown() {
@@ -46,6 +59,7 @@ class StudyInfoServiceTest extends TestConfig {
         studyCategoryMappingRepository.deleteAllInBatch();
         studyMemberRepository.deleteAllInBatch();
         studyCategoryRepository.deleteAllInBatch();
+        studyInfoRepository.deleteAllInBatch();
     }
 
     @Test
@@ -91,5 +105,72 @@ class StudyInfoServiceTest extends TestConfig {
 
         // joinCode 10자리가 잘 생성되었는지 검증
         assertEquals(registeredStudy.getJoinCode().length(), JOIN_CODE_LENGTH);
+    }
+
+    @Test
+    void 삭제_성공_테스트() {
+        // given
+
+        // 유저생성
+        User leaderUser = userRepository.save(UserFixture.generateAuthUserByPlatformId("a"));
+        User user1 = userRepository.save(UserFixture.generateAuthUserByPlatformId("b"));
+        User user2 = userRepository.save(UserFixture.generateAuthUserByPlatformId("c"));
+        User user3 = userRepository.save(UserFixture.generateAuthUserByPlatformId("d"));
+
+        // 스터디 생성
+        StudyInfo studyInfo = studyInfoRepository.save(generateStudyInfo(leaderUser.getId()));
+
+        // 스터디 멤버 생성
+        List<StudyMember> studyMembers = new ArrayList<>();
+        studyMembers.add(StudyMemberFixture.createStudyMemberLeader(leaderUser.getId(), studyInfo.getId()));
+        studyMembers.add(StudyMemberFixture.createDefaultStudyMember(user1.getId(), studyInfo.getId()));
+        studyMembers.add(StudyMemberFixture.createDefaultStudyMember(user2.getId(), studyInfo.getId()));
+        studyMembers.add(StudyMemberFixture.createDefaultStudyMember(user3.getId(), studyInfo.getId()));
+        studyMemberRepository.saveAll(studyMembers);
+
+        // when
+        studyInfoService.deleteStudy(leaderUser, studyInfo.getId());
+
+
+        // then
+        // 멤버는 지워지면 안된다
+        List<StudyMember> withdrawalMembers = studyMemberRepository.findByStudyInfoId(studyInfo.getId());
+        assertThat(withdrawalMembers).isNotNull().isNotEmpty();
+
+        // 멤버 상태는 STUDY_WITHDRAWAL이다.
+        for (StudyMember member : withdrawalMembers) {
+            assertThat(member.getStatus()).isEqualTo(StudyMemberStatus.STUDY_WITHDRAWAL);
+        }
+
+        // 스터디의 상태는 STUDY_DELETED이다.
+        assertEquals(studyInfoRepository.findById(studyInfo.getId()).get().getStatus(), StudyStatus.STUDY_DELETED);
+
+    }
+
+    @Test
+    void 스터디가_없을_경우_스터디_삭제_실패_테스트() {
+        Long invalidStudyInfoId = 987654321L;
+        // given
+        User user = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo studyInfo = studyInfoRepository.save(generateStudyInfo(user.getId()));
+        StudyMember studyMember = studyMemberRepository.save(StudyMemberFixture.createStudyMemberLeader(user.getId(), studyInfo.getId()));
+
+        // then
+        assertThrows(StudyInfoException.class, () -> {
+            studyInfoService.deleteStudy(user, invalidStudyInfoId);
+        }, "해당 스터디정보를 찾을 수 없습니다.");
+    }
+
+    @Test
+    void 유저가_스터디장이_아닐_경우_스터디_삭제_실패_테스트() {
+        // given
+        User user = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo studyInfo = studyInfoRepository.save(generateStudyInfo(user.getId()));
+        StudyMember studyMember = studyMemberRepository.save(StudyMemberFixture.createDefaultStudyMember(user.getId(), studyInfo.getId()));
+
+        // then
+        assertThrows(MemberException.class, () -> {
+            studyInfoService.deleteStudy(user, studyInfo.getId());
+        }, "스터디장이 아닙니다.");
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#124

### Pull Request Type

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용
* 스터디 삭제 api구현
        1. studyInfoId로 스터디가 있는 지 확인
        2. 스터디장이 맞는지 확인
        3. 스터디 상태정보를 STUDY_DELETED로 변경
        4. 모든 스터디원의 상태정보를 Withdrawal로 변경 
* 스터디 삭제 api 테스트, 예외 테스트 

스터디 삭제 부분에서 모든 데이터를 삭제하려했으나 끝난 스터디에 대한 정보도 볼 수 있게 하는 것이 좋은 거 같아 데이터를 남겨두었습니다!

## 💬 리뷰 요구사항

피드백 부탁드립니다~!