### PR TITLE
[BE] feat(#158): 스터디 댓글 리스트 조회 api 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/define/study/comment/study/repository/StudyCommentRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/comment/study/repository/StudyCommentRepository.java
@@ -3,5 +3,5 @@ package com.example.backend.domain.define.study.comment.study.repository;
 import com.example.backend.domain.define.study.comment.study.StudyComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StudyCommentRepository extends JpaRepository<StudyComment, Long> {
+public interface StudyCommentRepository extends JpaRepository<StudyComment, Long>, StudyCommentRepositoryCustom {
 }

--- a/backend/src/main/java/com/example/backend/domain/define/study/comment/study/repository/StudyCommentRepositoryCustom.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/comment/study/repository/StudyCommentRepositoryCustom.java
@@ -7,5 +7,5 @@ import java.util.List;
 public interface StudyCommentRepositoryCustom {
 
     // 스터디 댓글 리스트 조회 쿼리 - 커서 기반 페이지네이션
-    List<StudyCommentResponse> findStudyCommentListByUserIdJoinStudyInfo(Long userId, Long cursorIdx, Long limit);
+    List<StudyCommentResponse> findStudyCommentListByStudyInfoIdJoinUser(Long studyInfoId, Long cursorIdx, Long limit);
 }

--- a/backend/src/main/java/com/example/backend/domain/define/study/comment/study/repository/StudyCommentRepositoryCustom.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/comment/study/repository/StudyCommentRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.example.backend.domain.define.study.comment.study.repository;
+
+import com.example.backend.study.api.controller.comment.study.response.StudyCommentResponse;
+
+import java.util.List;
+
+public interface StudyCommentRepositoryCustom {
+
+    // 스터디 댓글 리스트 조회 쿼리 - 커서 기반 페이지네이션
+    List<StudyCommentResponse> findStudyCommentListByUserIdJoinStudyInfo(Long userId, Long cursorIdx, Long limit);
+}

--- a/backend/src/main/java/com/example/backend/domain/define/study/comment/study/repository/StudyCommentRepositoryImpl.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/comment/study/repository/StudyCommentRepositoryImpl.java
@@ -1,0 +1,57 @@
+package com.example.backend.domain.define.study.comment.study.repository;
+
+import com.example.backend.auth.api.controller.auth.response.UserInfoResponse;
+import com.example.backend.domain.define.study.comment.study.StudyComment;
+import com.example.backend.study.api.controller.comment.study.response.StudyCommentResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static com.example.backend.domain.define.account.user.QUser.user;
+import static com.example.backend.domain.define.study.comment.study.QStudyComment.studyComment;
+
+@Component
+@RequiredArgsConstructor
+public class StudyCommentRepositoryImpl implements StudyCommentRepositoryCustom{
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<StudyCommentResponse> findStudyCommentListByUserIdJoinStudyInfo(Long userId, Long cursorIdx, Long limit) {
+        JPAQuery<StudyCommentResponse> query = jpaQueryFactory
+                .select(Projections.constructor(
+                        StudyCommentResponse.class,
+                        studyComment.id,
+                        studyComment.studyInfoId,
+                        studyComment.userId,
+                        Projections.constructor(
+                                UserInfoResponse.class,
+                                user.id,
+                                user.role,
+                                user.githubId,
+                                user.name,
+                                user.profileImageUrl,
+                                user.pushAlarmYn,
+                                user.profilePublicYn,
+                                user.score,
+                                user.point
+                        )
+                ))
+                .from(studyComment)
+                .join(user).on(user.id.eq(studyComment.userId))
+                .orderBy(studyComment.id.desc());
+
+        // cursorIdx가 null이 아닌 경우 커서 기반으로 데이터 가져오도록
+        if (cursorIdx != null) {
+            query = query.where(studyComment.id.lt(cursorIdx));
+        }
+
+        // 커서 다음부터 limit만큼 가져오기
+        return query
+                .limit(limit)
+                .fetch();
+    }
+}

--- a/backend/src/main/java/com/example/backend/domain/define/study/comment/study/repository/StudyCommentRepositoryImpl.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/comment/study/repository/StudyCommentRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.example.backend.domain.define.study.comment.study.repository;
 import com.example.backend.auth.api.controller.auth.response.UserInfoResponse;
 import com.example.backend.domain.define.study.comment.study.StudyComment;
 import com.example.backend.study.api.controller.comment.study.response.StudyCommentResponse;
+import com.example.backend.study.api.service.comment.study.response.UserInfoForStudyCommentResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -13,6 +14,7 @@ import java.util.List;
 
 import static com.example.backend.domain.define.account.user.QUser.user;
 import static com.example.backend.domain.define.study.comment.study.QStudyComment.studyComment;
+import static javax.management.Query.eq;
 
 @Component
 @RequiredArgsConstructor
@@ -20,7 +22,7 @@ public class StudyCommentRepositoryImpl implements StudyCommentRepositoryCustom{
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<StudyCommentResponse> findStudyCommentListByUserIdJoinStudyInfo(Long userId, Long cursorIdx, Long limit) {
+    public List<StudyCommentResponse> findStudyCommentListByStudyInfoIdJoinUser(Long studyId, Long cursorIdx, Long limit) {
         JPAQuery<StudyCommentResponse> query = jpaQueryFactory
                 .select(Projections.constructor(
                         StudyCommentResponse.class,
@@ -28,20 +30,15 @@ public class StudyCommentRepositoryImpl implements StudyCommentRepositoryCustom{
                         studyComment.studyInfoId,
                         studyComment.userId,
                         Projections.constructor(
-                                UserInfoResponse.class,
+                                UserInfoForStudyCommentResponse.class,
                                 user.id,
-                                user.role,
-                                user.githubId,
                                 user.name,
-                                user.profileImageUrl,
-                                user.pushAlarmYn,
-                                user.profilePublicYn,
-                                user.score,
-                                user.point
+                                user.profileImageUrl
                         )
                 ))
                 .from(studyComment)
                 .join(user).on(user.id.eq(studyComment.userId))
+                .where(studyComment.studyInfoId.eq(studyId))
                 .orderBy(studyComment.id.desc());
 
         // cursorIdx가 null이 아닌 경우 커서 기반으로 데이터 가져오도록

--- a/backend/src/main/java/com/example/backend/study/api/controller/comment/study/StudyCommentController.java
+++ b/backend/src/main/java/com/example/backend/study/api/controller/comment/study/StudyCommentController.java
@@ -51,7 +51,7 @@ public class StudyCommentController {
                                          @PathVariable(name = "studyCommentId") Long studyCommentId,
                                          @Valid @RequestBody StudyCommentUpdateRequest studyCommentUpdateRequest) {
         authService.authenticate(studyCommentUpdateRequest.getUserId(), user);
-        studyCommentService.updateStudyComment(studyCommentUpdateRequest, studyCommentId);
+        studyCommentService.updateStudyComment(studyCommentUpdateRequest, studyInfoId, studyCommentId);
 
         return JsonResult.successOf("StudyComment update Success");
     }

--- a/backend/src/main/java/com/example/backend/study/api/controller/comment/study/StudyCommentController.java
+++ b/backend/src/main/java/com/example/backend/study/api/controller/comment/study/StudyCommentController.java
@@ -70,25 +70,20 @@ public class StudyCommentController {
     @ApiResponse(responseCode = "200",
             description = "스터디 댓글 조회 성공",
             content = @Content(schema = @Schema(implementation = StudyCommentListAndCursorIdxResponse.class)))
-    @GetMapping("/{studyInfoId}/comment/{userId}")
+    @GetMapping("/{studyInfoId}/comments")
     public JsonResult<?> StudyCommentList(@AuthenticationPrincipal User user,
                                           @PathVariable(name = "studyInfoId") Long studyInfoId,
-                                          @PathVariable(name = "userId") Long userId,
                                           @Min(value = 0, message = "Cursor index cannot be negative") @RequestParam(name = "cursorIdx") Long cursorIdx,
                                           @Min(value = 1, message = "Limit cannot be less than 1") @RequestParam(name = "limit", defaultValue = "5") Long limit) {
 
         studyMemberService.isValidateStudyMember(user, studyInfoId);
-        List<StudyCommentResponse> StudyCommentList = studyCommentService.selectStudyCommentList(userId, cursorIdx, limit);
+        List<StudyCommentResponse> StudyCommentList = studyCommentService.selectStudyCommentList(studyInfoId, cursorIdx, limit);
 
-        // 다음 cursorIdx
-        Long nextCursorIdx = 0L;
-        if (!StudyCommentList.isEmpty()) {
-            nextCursorIdx = StudyCommentList.get(StudyCommentList.size() - 1).getId();
-        }
-
-        return JsonResult.successOf(StudyCommentListAndCursorIdxResponse.builder()
+        StudyCommentListAndCursorIdxResponse response = (StudyCommentListAndCursorIdxResponse.builder()
                 .studyCommentList(StudyCommentList)
-                .cursorIdx(nextCursorIdx)
                 .build());
+        response.getNextCursorIdx();
+
+        return JsonResult.successOf(response);
     }
 }

--- a/backend/src/main/java/com/example/backend/study/api/controller/comment/study/StudyCommentController.java
+++ b/backend/src/main/java/com/example/backend/study/api/controller/comment/study/StudyCommentController.java
@@ -3,16 +3,24 @@ package com.example.backend.study.api.controller.comment.study;
 import com.example.backend.auth.api.service.auth.AuthService;
 import com.example.backend.common.response.JsonResult;
 import com.example.backend.domain.define.account.user.User;
+import com.example.backend.domain.define.study.comment.study.StudyComment;
 import com.example.backend.study.api.controller.comment.study.request.StudyCommentRegisterRequest;
 import com.example.backend.study.api.controller.comment.study.request.StudyCommentUpdateRequest;
+import com.example.backend.study.api.controller.comment.study.response.StudyCommentListAndCursorIdxResponse;
+import com.example.backend.study.api.controller.comment.study.response.StudyCommentResponse;
 import com.example.backend.study.api.service.comment.study.StudyCommentService;
 import com.example.backend.study.api.service.member.StudyMemberService;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -57,5 +65,30 @@ public class StudyCommentController {
         studyCommentService.deleteStudyComment(user, studyInfoId, studyCommentId);
 
         return JsonResult.successOf("StudyComment deleted successfully");
+    }
+
+    @ApiResponse(responseCode = "200",
+            description = "스터디 댓글 조회 성공",
+            content = @Content(schema = @Schema(implementation = StudyCommentListAndCursorIdxResponse.class)))
+    @GetMapping("/{studyInfoId}/comment/{userId}")
+    public JsonResult<?> StudyCommentList(@AuthenticationPrincipal User user,
+                                          @PathVariable(name = "studyInfoId") Long studyInfoId,
+                                          @PathVariable(name = "userId") Long userId,
+                                          @Min(value = 0, message = "Cursor index cannot be negative") @RequestParam(name = "cursorIdx") Long cursorIdx,
+                                          @Min(value = 1, message = "Limit cannot be less than 1") @RequestParam(name = "limit", defaultValue = "5") Long limit) {
+
+        studyMemberService.isValidateStudyMember(user, studyInfoId);
+        List<StudyCommentResponse> StudyCommentList = studyCommentService.selectStudyCommentList(userId, cursorIdx, limit);
+
+        // 다음 cursorIdx
+        Long nextCursorIdx = 0L;
+        if (!StudyCommentList.isEmpty()) {
+            nextCursorIdx = StudyCommentList.get(StudyCommentList.size() - 1).getId();
+        }
+
+        return JsonResult.successOf(StudyCommentListAndCursorIdxResponse.builder()
+                .studyCommentList(StudyCommentList)
+                .cursorIdx(nextCursorIdx)
+                .build());
     }
 }

--- a/backend/src/main/java/com/example/backend/study/api/controller/comment/study/StudyCommentController.java
+++ b/backend/src/main/java/com/example/backend/study/api/controller/comment/study/StudyCommentController.java
@@ -77,12 +77,7 @@ public class StudyCommentController {
                                           @Min(value = 1, message = "Limit cannot be less than 1") @RequestParam(name = "limit", defaultValue = "5") Long limit) {
 
         studyMemberService.isValidateStudyMember(user, studyInfoId);
-        List<StudyCommentResponse> StudyCommentList = studyCommentService.selectStudyCommentList(studyInfoId, cursorIdx, limit);
-
-        StudyCommentListAndCursorIdxResponse response = (StudyCommentListAndCursorIdxResponse.builder()
-                .studyCommentList(StudyCommentList)
-                .build());
-        response.getNextCursorIdx();
+        StudyCommentListAndCursorIdxResponse response = studyCommentService.selectStudyCommentList(studyInfoId, cursorIdx, limit);
 
         return JsonResult.successOf(response);
     }

--- a/backend/src/main/java/com/example/backend/study/api/controller/comment/study/response/StudyCommentListAndCursorIdxResponse.java
+++ b/backend/src/main/java/com/example/backend/study/api/controller/comment/study/response/StudyCommentListAndCursorIdxResponse.java
@@ -9,10 +9,13 @@ import java.util.List;
 public class StudyCommentListAndCursorIdxResponse {
     private List<StudyCommentResponse> studyCommentList;
     private Long cursorIdx;
-
     @Builder
     public StudyCommentListAndCursorIdxResponse(List<StudyCommentResponse> studyCommentList, Long cursorIdx) {
         this.studyCommentList = studyCommentList;
         this.cursorIdx = cursorIdx;
+    }
+    public void getNextCursorIdx() {
+        cursorIdx = studyCommentList == null || studyCommentList.isEmpty() ?
+                0L : studyCommentList.get(studyCommentList.size() - 1).getId();
     }
 }

--- a/backend/src/main/java/com/example/backend/study/api/controller/comment/study/response/StudyCommentListAndCursorIdxResponse.java
+++ b/backend/src/main/java/com/example/backend/study/api/controller/comment/study/response/StudyCommentListAndCursorIdxResponse.java
@@ -1,0 +1,18 @@
+package com.example.backend.study.api.controller.comment.study.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class StudyCommentListAndCursorIdxResponse {
+    private List<StudyCommentResponse> studyCommentList;
+    private Long cursorIdx;
+
+    @Builder
+    public StudyCommentListAndCursorIdxResponse(List<StudyCommentResponse> studyCommentList, Long cursorIdx) {
+        this.studyCommentList = studyCommentList;
+        this.cursorIdx = cursorIdx;
+    }
+}

--- a/backend/src/main/java/com/example/backend/study/api/controller/comment/study/response/StudyCommentResponse.java
+++ b/backend/src/main/java/com/example/backend/study/api/controller/comment/study/response/StudyCommentResponse.java
@@ -1,0 +1,23 @@
+package com.example.backend.study.api.controller.comment.study.response;
+
+import com.example.backend.auth.api.controller.auth.response.UserInfoResponse;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class StudyCommentResponse {
+    private Long id;
+    private Long studyInfoId;
+    private Long userId;
+    private UserInfoResponse userInfoResponse;
+
+    @Builder
+    public StudyCommentResponse(Long id, Long studyInfoId, Long userId, UserInfoResponse userInfoResponse) {
+        this.id = id;
+        this.studyInfoId = studyInfoId;
+        this.userId = userId;
+        this.userInfoResponse = userInfoResponse;
+    }
+}

--- a/backend/src/main/java/com/example/backend/study/api/controller/comment/study/response/StudyCommentResponse.java
+++ b/backend/src/main/java/com/example/backend/study/api/controller/comment/study/response/StudyCommentResponse.java
@@ -1,6 +1,7 @@
 package com.example.backend.study.api.controller.comment.study.response;
 
 import com.example.backend.auth.api.controller.auth.response.UserInfoResponse;
+import com.example.backend.study.api.service.comment.study.response.UserInfoForStudyCommentResponse;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -11,10 +12,10 @@ public class StudyCommentResponse {
     private Long id;
     private Long studyInfoId;
     private Long userId;
-    private UserInfoResponse userInfoResponse;
+    private UserInfoForStudyCommentResponse userInfoResponse;
 
     @Builder
-    public StudyCommentResponse(Long id, Long studyInfoId, Long userId, UserInfoResponse userInfoResponse) {
+    public StudyCommentResponse(Long id, Long studyInfoId, Long userId, UserInfoForStudyCommentResponse userInfoResponse) {
         this.id = id;
         this.studyInfoId = studyInfoId;
         this.userId = userId;

--- a/backend/src/main/java/com/example/backend/study/api/service/comment/study/StudyCommentService.java
+++ b/backend/src/main/java/com/example/backend/study/api/service/comment/study/StudyCommentService.java
@@ -12,6 +12,7 @@ import com.example.backend.domain.define.study.info.repository.StudyInfoReposito
 import com.example.backend.domain.define.study.member.repository.StudyMemberRepository;
 import com.example.backend.study.api.controller.comment.study.request.StudyCommentRegisterRequest;
 import com.example.backend.study.api.controller.comment.study.request.StudyCommentUpdateRequest;
+import com.example.backend.study.api.controller.comment.study.response.StudyCommentListAndCursorIdxResponse;
 import com.example.backend.study.api.controller.comment.study.response.StudyCommentResponse;
 import com.example.backend.study.api.service.member.StudyMemberService;
 import lombok.RequiredArgsConstructor;
@@ -92,8 +93,14 @@ public class StudyCommentService {
         }
         studyCommentRepository.deleteById(studyCommentId);
     }
-    public List<StudyCommentResponse> selectStudyCommentList(Long studyInfoId, Long cursorIdx, Long limit) {
-        return studyCommentRepository.findStudyCommentListByStudyInfoIdJoinUser(studyInfoId, cursorIdx, limit);
+    public StudyCommentListAndCursorIdxResponse selectStudyCommentList(Long studyInfoId, Long cursorIdx, Long limit) {
+        List<StudyCommentResponse> studyCommentResponseList =
+                studyCommentRepository.findStudyCommentListByStudyInfoIdJoinUser(studyInfoId, cursorIdx, limit);
+        StudyCommentListAndCursorIdxResponse response = (StudyCommentListAndCursorIdxResponse.builder()
+                .studyCommentList(studyCommentResponseList)
+                .build());
+        response.getNextCursorIdx();
+        return response;
     }
 
     // StudyComment 생성 로직

--- a/backend/src/main/java/com/example/backend/study/api/service/comment/study/StudyCommentService.java
+++ b/backend/src/main/java/com/example/backend/study/api/service/comment/study/StudyCommentService.java
@@ -94,6 +94,12 @@ public class StudyCommentService {
         studyCommentRepository.deleteById(studyCommentId);
     }
     public StudyCommentListAndCursorIdxResponse selectStudyCommentList(Long studyInfoId, Long cursorIdx, Long limit) {
+        // 스터디가 있는지 확인
+        studyInfoRepository.findById(studyInfoId).orElseThrow(() -> {
+            log.warn(">>>> {} : {} <<<<", studyInfoId, ExceptionMessage.STUDY_INFO_NOT_FOUND.getText());
+            throw new StudyInfoException(ExceptionMessage.STUDY_INFO_NOT_FOUND);
+        });
+
         List<StudyCommentResponse> studyCommentResponseList =
                 studyCommentRepository.findStudyCommentListByStudyInfoIdJoinUser(studyInfoId, cursorIdx, limit);
         StudyCommentListAndCursorIdxResponse response = (StudyCommentListAndCursorIdxResponse.builder()

--- a/backend/src/main/java/com/example/backend/study/api/service/comment/study/StudyCommentService.java
+++ b/backend/src/main/java/com/example/backend/study/api/service/comment/study/StudyCommentService.java
@@ -12,11 +12,14 @@ import com.example.backend.domain.define.study.info.repository.StudyInfoReposito
 import com.example.backend.domain.define.study.member.repository.StudyMemberRepository;
 import com.example.backend.study.api.controller.comment.study.request.StudyCommentRegisterRequest;
 import com.example.backend.study.api.controller.comment.study.request.StudyCommentUpdateRequest;
+import com.example.backend.study.api.controller.comment.study.response.StudyCommentResponse;
 import com.example.backend.study.api.service.member.StudyMemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -89,6 +92,10 @@ public class StudyCommentService {
         }
         studyCommentRepository.deleteById(studyCommentId);
     }
+    public List<StudyCommentResponse> selectStudyCommentList(Long userId, Long cursorIdx, Long limit) {
+        return studyCommentRepository.findStudyCommentListByUserIdJoinStudyInfo(userId, cursorIdx, limit);
+    }
+
     // StudyComment 생성 로직
     private StudyComment createStudyComment(StudyCommentRegisterRequest studyCommentRegisterRequest, Long studyInfoId) {
         return StudyComment.builder()

--- a/backend/src/main/java/com/example/backend/study/api/service/comment/study/StudyCommentService.java
+++ b/backend/src/main/java/com/example/backend/study/api/service/comment/study/StudyCommentService.java
@@ -52,8 +52,14 @@ public class StudyCommentService {
     }
 
     @Transactional
-    public void updateStudyComment(StudyCommentUpdateRequest request, Long studyCommentId) {
-        // StudyComment 조회
+    public void updateStudyComment(StudyCommentUpdateRequest request,Long studyInfoId, Long studyCommentId) {
+        // 스터디 조회
+        studyInfoRepository.findById(studyInfoId).orElseThrow(() -> {
+            log.warn(">>>> {} : {} <<<<", studyInfoId, ExceptionMessage.STUDY_INFO_NOT_FOUND.getText());
+            throw new StudyInfoException(ExceptionMessage.STUDY_INFO_NOT_FOUND);
+        });
+
+        // 댓글 조회
         StudyComment studyComment = studyCommentRepository.findById(studyCommentId).orElseThrow(() -> {
             log.warn(">>>> {} : {} <<<<", studyCommentId, ExceptionMessage.STUDY_COMMENT_NOT_FOUND.getText());
             return new StudyCommentException(ExceptionMessage.STUDY_COMMENT_NOT_FOUND);

--- a/backend/src/main/java/com/example/backend/study/api/service/comment/study/StudyCommentService.java
+++ b/backend/src/main/java/com/example/backend/study/api/service/comment/study/StudyCommentService.java
@@ -92,8 +92,8 @@ public class StudyCommentService {
         }
         studyCommentRepository.deleteById(studyCommentId);
     }
-    public List<StudyCommentResponse> selectStudyCommentList(Long userId, Long cursorIdx, Long limit) {
-        return studyCommentRepository.findStudyCommentListByUserIdJoinStudyInfo(userId, cursorIdx, limit);
+    public List<StudyCommentResponse> selectStudyCommentList(Long studyInfoId, Long cursorIdx, Long limit) {
+        return studyCommentRepository.findStudyCommentListByStudyInfoIdJoinUser(studyInfoId, cursorIdx, limit);
     }
 
     // StudyComment 생성 로직

--- a/backend/src/main/java/com/example/backend/study/api/service/comment/study/response/UserInfoForStudyCommentResponse.java
+++ b/backend/src/main/java/com/example/backend/study/api/service/comment/study/response/UserInfoForStudyCommentResponse.java
@@ -1,0 +1,19 @@
+package com.example.backend.study.api.service.comment.study.response;
+
+import com.example.backend.domain.define.account.user.constant.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInfoForStudyCommentResponse {
+    private Long userId;
+
+    private String name;
+
+    private String profileImageUrl;
+}

--- a/backend/src/test/java/com/example/backend/domain/define/study/comment/StudyCommentFixture.java
+++ b/backend/src/test/java/com/example/backend/domain/define/study/comment/StudyCommentFixture.java
@@ -3,6 +3,9 @@ package com.example.backend.domain.define.study.comment;
 import com.example.backend.domain.define.study.comment.study.StudyComment;
 import com.example.backend.study.api.controller.comment.study.request.StudyCommentRegisterRequest;
 import com.example.backend.study.api.controller.comment.study.request.StudyCommentUpdateRequest;
+import com.example.backend.study.api.controller.comment.study.response.StudyCommentListAndCursorIdxResponse;
+import com.example.backend.study.api.controller.comment.study.response.StudyCommentResponse;
+import com.example.backend.study.api.service.comment.study.response.UserInfoForStudyCommentResponse;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,6 +39,31 @@ public class StudyCommentFixture {
         return StudyCommentUpdateRequest.builder()
                 .userId(userId)
                 .content("ChangedContent")
+                .build();
+    }
+    public static StudyCommentResponse createDefaultStudyCommentResponse(Long userId, Long studyInfoId) {
+        return StudyCommentResponse.builder()
+                .studyInfoId(studyInfoId)
+                .userId(userId)
+                .userInfoResponse(createDefaultUserInfoResponse(userId))
+                .build();
+    }
+    public static StudyCommentListAndCursorIdxResponse generateStudyCommentListAndCursorIdxResponse(Long userId, Long studyInfoId) {
+        Long cursorIdx = 5L;
+        List<StudyCommentResponse> comments = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            comments.add(createDefaultStudyCommentResponse(userId, studyInfoId));
+        }
+        return StudyCommentListAndCursorIdxResponse.builder()
+                .studyCommentList(comments)
+                .cursorIdx(cursorIdx)
+                .build();
+    }
+    public static UserInfoForStudyCommentResponse createDefaultUserInfoResponse(Long userId) {
+        return UserInfoForStudyCommentResponse.builder()
+                .userId(userId)
+                .name("user")
+                .profileImageUrl("profileImageUrl")
                 .build();
     }
 }

--- a/backend/src/test/java/com/example/backend/domain/define/study/comment/StudyCommentFixture.java
+++ b/backend/src/test/java/com/example/backend/domain/define/study/comment/StudyCommentFixture.java
@@ -4,6 +4,9 @@ import com.example.backend.domain.define.study.comment.study.StudyComment;
 import com.example.backend.study.api.controller.comment.study.request.StudyCommentRegisterRequest;
 import com.example.backend.study.api.controller.comment.study.request.StudyCommentUpdateRequest;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class StudyCommentFixture {
 
     public static StudyComment createDefaultStudyComment(Long userId, Long studyInfoId) {
@@ -12,6 +15,15 @@ public class StudyCommentFixture {
                 .userId(userId)
                 .content("스터디 댓글")
                 .build();
+    }
+
+    // 테스트용 스터디 댓글 리스트 생성 메서드
+    public static List<StudyComment> createDefaultStudyCommentList(int count, Long userId, Long studyInfoId) {
+        List<StudyComment> studyComments = new ArrayList<>();
+        for (int i = 1; i <= count; i++) {
+            studyComments.add(createDefaultStudyComment(userId, studyInfoId));
+        }
+        return studyComments;
     }
     public static StudyCommentRegisterRequest createDefaultStudyCommentRegisterRequest(Long userId) {
         return StudyCommentRegisterRequest.builder()

--- a/backend/src/test/java/com/example/backend/domain/define/study/comment/study/repository/StudyCommentRepositoryTest.java
+++ b/backend/src/test/java/com/example/backend/domain/define/study/comment/study/repository/StudyCommentRepositoryTest.java
@@ -56,6 +56,7 @@ class StudyCommentRepositoryTest extends TestConfig {
         for (StudyCommentResponse b : StudyCommentListResponse) {
             assertTrue(b.getId() < cursorIdx);
             assertEquals(user.getId(), b.getUserInfoResponse().getUserId());
+            assertEquals(study.getId(), b.getStudyInfoId());
         }
     }
 
@@ -76,6 +77,7 @@ class StudyCommentRepositoryTest extends TestConfig {
         assertEquals(LIMIT, StudyCommentListResponse.size());
         for (StudyCommentResponse b : StudyCommentListResponse) {
             assertEquals(user.getId(), b.getUserInfoResponse().getUserId());
+            assertEquals(study.getId(), b.getStudyInfoId());
         }
     }
 }

--- a/backend/src/test/java/com/example/backend/domain/define/study/comment/study/repository/StudyCommentRepositoryTest.java
+++ b/backend/src/test/java/com/example/backend/domain/define/study/comment/study/repository/StudyCommentRepositoryTest.java
@@ -1,0 +1,83 @@
+package com.example.backend.domain.define.study.comment.study.repository;
+
+import com.example.backend.auth.TestConfig;
+import com.example.backend.auth.config.fixture.UserFixture;
+import com.example.backend.domain.define.account.user.User;
+import com.example.backend.domain.define.study.comment.StudyCommentFixture;
+import com.example.backend.domain.define.study.comment.study.StudyComment;
+import com.example.backend.domain.define.study.info.StudyInfo;
+import com.example.backend.domain.define.study.info.StudyInfoFixture;
+import com.example.backend.domain.define.study.info.repository.StudyInfoRepository;
+import com.example.backend.study.api.controller.comment.study.response.StudyCommentResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import com.example.backend.domain.define.account.user.repository.UserRepository;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SuppressWarnings("NonAsciiCharacters")
+class StudyCommentRepositoryTest extends TestConfig {
+    private final static int DATA_SIZE = 20;
+    private final static Long LIMIT = 10L;
+
+    @Autowired
+    private StudyCommentRepository studyCommentRepository;
+
+    @Autowired
+    private StudyInfoRepository studyInfoRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @AfterEach
+    void tearDown() {
+        studyCommentRepository.deleteAllInBatch();
+        studyInfoRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void 스터디_댓글_리스트_조회_쿼리_테스트() {
+        // given
+        Long cursorIdx = 25L;
+
+        User user = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.createDefaultPublicStudyInfo(user.getId()));
+
+        List<StudyComment> StudyCommentList = StudyCommentFixture.createDefaultStudyCommentList(DATA_SIZE, user.getId(), study.getId());
+        studyCommentRepository.saveAll(StudyCommentList);
+
+        // when
+        List<StudyCommentResponse> StudyCommentListResponse = studyCommentRepository.findStudyCommentListByUserIdJoinStudyInfo(user.getId(), cursorIdx, LIMIT);
+
+        // then
+        for (StudyCommentResponse b : StudyCommentListResponse) {
+            assertTrue(b.getId() < cursorIdx);
+            assertEquals(user.getId(), b.getUserInfoResponse().getUserId());
+            assertEquals(user.getGithubId(), b.getUserInfoResponse().getGithubId());
+        }
+    }
+
+
+    @Test
+    void cursor가_null인_경우_스터디_댓글_리스트_조회_쿼리_테스트() {
+        // given
+        User user = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.createDefaultPublicStudyInfo(user.getId()));
+
+        List<StudyComment> StudyCommentList = StudyCommentFixture.createDefaultStudyCommentList(DATA_SIZE, user.getId(), study.getId());
+        studyCommentRepository.saveAll(StudyCommentList);
+
+        // when
+        List<StudyCommentResponse> StudyCommentListResponse = studyCommentRepository.findStudyCommentListByUserIdJoinStudyInfo(user.getId(), null, LIMIT);
+
+        // then
+        assertEquals(LIMIT, StudyCommentListResponse.size());
+        for (StudyCommentResponse b : StudyCommentListResponse) {
+            assertEquals(user.getId(), b.getUserInfoResponse().getUserId());
+            assertEquals(user.getGithubId(), b.getUserInfoResponse().getGithubId());
+        }
+    }
+}

--- a/backend/src/test/java/com/example/backend/domain/define/study/comment/study/repository/StudyCommentRepositoryTest.java
+++ b/backend/src/test/java/com/example/backend/domain/define/study/comment/study/repository/StudyCommentRepositoryTest.java
@@ -50,13 +50,12 @@ class StudyCommentRepositoryTest extends TestConfig {
         studyCommentRepository.saveAll(StudyCommentList);
 
         // when
-        List<StudyCommentResponse> StudyCommentListResponse = studyCommentRepository.findStudyCommentListByUserIdJoinStudyInfo(user.getId(), cursorIdx, LIMIT);
+        List<StudyCommentResponse> StudyCommentListResponse = studyCommentRepository.findStudyCommentListByStudyInfoIdJoinUser(study.getId(), cursorIdx, LIMIT);
 
         // then
         for (StudyCommentResponse b : StudyCommentListResponse) {
             assertTrue(b.getId() < cursorIdx);
             assertEquals(user.getId(), b.getUserInfoResponse().getUserId());
-            assertEquals(user.getGithubId(), b.getUserInfoResponse().getGithubId());
         }
     }
 
@@ -71,13 +70,12 @@ class StudyCommentRepositoryTest extends TestConfig {
         studyCommentRepository.saveAll(StudyCommentList);
 
         // when
-        List<StudyCommentResponse> StudyCommentListResponse = studyCommentRepository.findStudyCommentListByUserIdJoinStudyInfo(user.getId(), null, LIMIT);
+        List<StudyCommentResponse> StudyCommentListResponse = studyCommentRepository.findStudyCommentListByStudyInfoIdJoinUser(study.getId(), null, LIMIT);
 
         // then
         assertEquals(LIMIT, StudyCommentListResponse.size());
         for (StudyCommentResponse b : StudyCommentListResponse) {
             assertEquals(user.getId(), b.getUserInfoResponse().getUserId());
-            assertEquals(user.getGithubId(), b.getUserInfoResponse().getGithubId());
         }
     }
 }

--- a/backend/src/test/java/com/example/backend/study/api/controller/comment/study/StudyCommentControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/controller/comment/study/StudyCommentControllerTest.java
@@ -18,6 +18,7 @@ import com.example.backend.domain.define.study.info.repository.StudyInfoReposito
 import com.example.backend.domain.define.study.member.StudyMemberFixture;
 import com.example.backend.study.api.controller.comment.study.request.StudyCommentRegisterRequest;
 import com.example.backend.study.api.controller.comment.study.request.StudyCommentUpdateRequest;
+import com.example.backend.study.api.controller.comment.study.response.StudyCommentListAndCursorIdxResponse;
 import com.example.backend.study.api.service.comment.study.StudyCommentService;
 import com.example.backend.study.api.service.member.StudyMemberService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,7 +29,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.ArrayList;
 import java.util.Map;
 
 import static com.example.backend.auth.config.fixture.UserFixture.generateAuthUser;
@@ -169,10 +169,12 @@ class StudyCommentControllerTest extends TestConfig {
         Map<String, String> map = TokenUtil.createTokenMap(user);
         String accessToken = jwtService.generateAccessToken(map, user);
         String refreshToken = jwtService.generateRefreshToken(map, user);
+        StudyCommentListAndCursorIdxResponse response
+                = StudyCommentFixture.generateStudyCommentListAndCursorIdxResponse(user.getId(), studyInfo.getId());
 
         when(authService.authenticate(any(Long.class), any(User.class))).thenReturn(UserInfoResponse.builder().build());
         when(studyCommentService.selectStudyCommentList(any(Long.class), any(Long.class), any(Long.class)))
-                .thenReturn(new ArrayList<>());
+                .thenReturn(response);
 
         // when
         mockMvc.perform(get("/study/"+studyInfo.getId()+"/comments")

--- a/backend/src/test/java/com/example/backend/study/api/controller/comment/study/StudyCommentControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/controller/comment/study/StudyCommentControllerTest.java
@@ -202,9 +202,10 @@ class StudyCommentControllerTest extends TestConfig {
         String accessToken = jwtService.generateAccessToken(map, user);
         String refreshToken = jwtService.generateRefreshToken(map, user);
 
-        when(studyMemberService.isValidateStudyLeader(any(User.class), any(Long.class)))
-                .thenReturn(UserInfoResponse.of(user));
-        
+        doThrow(new AuthException(ExceptionMessage.UNAUTHORIZED_AUTHORITY))
+                .when(studyMemberService)
+                .isValidateStudyMember(any(User.class), any(Long.class));
+
         // when
         mockMvc.perform(get("/study/"+studyInfo.getId()+"/comments")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/com/example/backend/study/api/controller/comment/study/StudyCommentControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/controller/comment/study/StudyCommentControllerTest.java
@@ -120,7 +120,7 @@ class StudyCommentControllerTest extends TestConfig {
 
         //when
         when(authService.authenticate(any(Long.class), any(User.class))).thenReturn(UserInfoResponse.of(savedUser));
-        doNothing().when(studyCommentService).updateStudyComment(any(StudyCommentUpdateRequest.class), any(Long.class));
+        doNothing().when(studyCommentService).updateStudyComment(any(StudyCommentUpdateRequest.class), any(Long.class), any(Long.class));
 
         //then
         mockMvc.perform(patch("/study/" + studyInfo.getId() + "/comment/" + studyComment.getId())

--- a/backend/src/test/java/com/example/backend/study/api/controller/comment/study/StudyCommentControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/controller/comment/study/StudyCommentControllerTest.java
@@ -202,12 +202,9 @@ class StudyCommentControllerTest extends TestConfig {
         String accessToken = jwtService.generateAccessToken(map, user);
         String refreshToken = jwtService.generateRefreshToken(map, user);
 
-        doNothing().when(studyMemberService).isValidateStudyMember(any(User.class), any(Long.class));
-        doThrow(new AuthException(ExceptionMessage.UNAUTHORIZED_AUTHORITY))
-                .when(studyMemberService)
-                .isValidateStudyMember(any(User.class), any(Long.class));
-
-
+        when(studyMemberService.isValidateStudyLeader(any(User.class), any(Long.class)))
+                .thenReturn(UserInfoResponse.of(user));
+        
         // when
         mockMvc.perform(get("/study/"+studyInfo.getId()+"/comments")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/com/example/backend/study/api/controller/comment/study/StudyCommentControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/controller/comment/study/StudyCommentControllerTest.java
@@ -175,7 +175,7 @@ class StudyCommentControllerTest extends TestConfig {
                 .thenReturn(new ArrayList<>());
 
         // when
-        mockMvc.perform(get("/study/"+studyInfo.getId()+"/comment/"+user.getId())
+        mockMvc.perform(get("/study/"+studyInfo.getId()+"/comments")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .param("cursorIdx", "1")
@@ -207,7 +207,7 @@ class StudyCommentControllerTest extends TestConfig {
 
 
         // when
-        mockMvc.perform(get("/study/"+studyInfo.getId()+"/comment/"+user.getId())
+        mockMvc.perform(get("/study/"+studyInfo.getId()+"/comments")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .param("cursorIdx", "1")
@@ -231,7 +231,7 @@ class StudyCommentControllerTest extends TestConfig {
         String refreshToken = jwtService.generateRefreshToken(map, user);
 
         // when
-        mockMvc.perform(get("/study/"+studyInfo.getId()+"/comment/"+user.getId())
+        mockMvc.perform(get("/study/"+studyInfo.getId()+"/comments")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .param("cursorIdx", "1")

--- a/backend/src/test/java/com/example/backend/study/api/controller/comment/study/StudyCommentControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/controller/comment/study/StudyCommentControllerTest.java
@@ -4,6 +4,8 @@ import com.example.backend.auth.TestConfig;
 import com.example.backend.auth.api.controller.auth.response.UserInfoResponse;
 import com.example.backend.auth.api.service.auth.AuthService;
 import com.example.backend.auth.api.service.jwt.JwtService;
+import com.example.backend.common.exception.ExceptionMessage;
+import com.example.backend.common.exception.auth.AuthException;
 import com.example.backend.common.utils.TokenUtil;
 import com.example.backend.domain.define.account.user.User;
 import com.example.backend.domain.define.account.user.repository.UserRepository;
@@ -26,12 +28,12 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.ArrayList;
 import java.util.Map;
 
 import static com.example.backend.auth.config.fixture.UserFixture.generateAuthUser;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -155,6 +157,90 @@ class StudyCommentControllerTest extends TestConfig {
                 .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("StudyComment deleted successfully"))
+                .andDo(print());
+    }
+
+    @Test
+    void 스터디_댓글_조회_성공_테스트() throws Exception {
+        // given
+        User user = userRepository.save(generateAuthUser());
+        StudyInfo studyInfo = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
+
+        Map<String, String> map = TokenUtil.createTokenMap(user);
+        String accessToken = jwtService.generateAccessToken(map, user);
+        String refreshToken = jwtService.generateRefreshToken(map, user);
+
+        when(authService.authenticate(any(Long.class), any(User.class))).thenReturn(UserInfoResponse.builder().build());
+        when(studyCommentService.selectStudyCommentList(any(Long.class), any(Long.class), any(Long.class)))
+                .thenReturn(new ArrayList<>());
+
+        // when
+        mockMvc.perform(get("/study/"+studyInfo.getId()+"/comment/"+user.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
+                        .param("cursorIdx", "1")
+                        .param("limit", "5"))
+
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.res_code").value(200))
+                .andExpect(jsonPath("$.res_msg").value("OK"))
+                .andExpect(jsonPath("$.res_obj").isNotEmpty())
+                .andDo(print());
+
+    }
+
+    @Test
+    void 스터디_댓글_조회_실패_테스트() throws Exception {
+        // given
+        User user = userRepository.save(generateAuthUser());
+        StudyInfo studyInfo = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
+
+        Map<String, String> map = TokenUtil.createTokenMap(user);
+        String accessToken = jwtService.generateAccessToken(map, user);
+        String refreshToken = jwtService.generateRefreshToken(map, user);
+
+        doNothing().when(studyMemberService).isValidateStudyMember(any(User.class), any(Long.class));
+        doThrow(new AuthException(ExceptionMessage.UNAUTHORIZED_AUTHORITY))
+                .when(studyMemberService)
+                .isValidateStudyMember(any(User.class), any(Long.class));
+
+
+        // when
+        mockMvc.perform(get("/study/"+studyInfo.getId()+"/comment/"+user.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
+                        .param("cursorIdx", "1")
+                        .param("limit", "5"))
+
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(jsonPath("$.res_msg").value(ExceptionMessage.UNAUTHORIZED_AUTHORITY.getText()))
+                .andDo(print());
+    }
+
+    @Test
+    void 스터디_댓글_조회_유효성_검증_실패_테스트() throws Exception {
+        // given
+        User user = userRepository.save(generateAuthUser());
+        StudyInfo studyInfo = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
+
+        Map<String, String> map = TokenUtil.createTokenMap(user);
+        String accessToken = jwtService.generateAccessToken(map, user);
+        String refreshToken = jwtService.generateRefreshToken(map, user);
+
+        // when
+        mockMvc.perform(get("/study/"+studyInfo.getId()+"/comment/"+user.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
+                        .param("cursorIdx", "1")
+                        .param("limit", "-1"))
+
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(jsonPath("$.res_msg").value("400 BAD_REQUEST \"Validation failure\""))
                 .andDo(print());
     }
 }

--- a/backend/src/test/java/com/example/backend/study/api/service/comment/study/StudyCommentServiceTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/service/comment/study/StudyCommentServiceTest.java
@@ -16,6 +16,7 @@ import com.example.backend.domain.define.study.member.StudyMemberFixture;
 import com.example.backend.domain.define.study.member.repository.StudyMemberRepository;
 import com.example.backend.study.api.controller.comment.study.request.StudyCommentRegisterRequest;
 import com.example.backend.study.api.controller.comment.study.request.StudyCommentUpdateRequest;
+import com.example.backend.study.api.controller.comment.study.response.StudyCommentListAndCursorIdxResponse;
 import com.example.backend.study.api.controller.comment.study.response.StudyCommentResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -232,9 +233,9 @@ class StudyCommentServiceTest extends TestConfig {
         studyCommentRepository.saveAll(studyCommentList);
 
         // when
-        List<StudyCommentResponse> studyCommentListResponse = studyCommentService.selectStudyCommentList(study.getId(), cursorIdx, LIMIT);
+        StudyCommentListAndCursorIdxResponse studyCommentListResponse = studyCommentService.selectStudyCommentList(study.getId(), cursorIdx, LIMIT);
 
-        for (StudyCommentResponse comment : studyCommentListResponse) {
+        for (StudyCommentResponse comment : studyCommentListResponse.getStudyCommentList()) {
             assertTrue(comment.getId() < cursorIdx);
         }
     }
@@ -251,9 +252,9 @@ class StudyCommentServiceTest extends TestConfig {
         studyCommentRepository.saveAll(studyCommentList);
 
         // when
-        List<StudyCommentResponse> studyCommentListResponse = studyCommentService.selectStudyCommentList(study.getId(), cursorIdx, LIMIT);
+        StudyCommentListAndCursorIdxResponse studyCommentListResponse = studyCommentService.selectStudyCommentList(study.getId(), cursorIdx, LIMIT);
 
-        for (StudyCommentResponse comment : studyCommentListResponse) {
+        for (StudyCommentResponse comment : studyCommentListResponse.getStudyCommentList()) {
             assertTrue(comment.getId() < cursorIdx);
         }
     }
@@ -268,9 +269,9 @@ class StudyCommentServiceTest extends TestConfig {
         studyCommentRepository.saveAll(studyCommentList);
 
         // when
-        List<StudyCommentResponse> studyCommentListResponse = studyCommentService.selectStudyCommentList(study.getId(), null, LIMIT);
+        StudyCommentListAndCursorIdxResponse studyCommentListResponse = studyCommentService.selectStudyCommentList(study.getId(), null, LIMIT);
 
-        assertEquals(LIMIT, studyCommentListResponse.size());
+        assertEquals(LIMIT, studyCommentListResponse.getStudyCommentList().size());
     }
 
     @Test
@@ -288,10 +289,10 @@ class StudyCommentServiceTest extends TestConfig {
         studyCommentRepository.save(StudyCommentFixture.createDefaultStudyComment(userC.getId(), study.getId()));
 
         // when
-        List<StudyCommentResponse> studyCommentResponse = studyCommentService.selectStudyCommentList(study.getId(),  null, LIMIT);
+        StudyCommentListAndCursorIdxResponse studyCommentResponse = studyCommentService.selectStudyCommentList(study.getId(),  null, LIMIT);
 
         // then
-        assertEquals(expectedSize, studyCommentResponse.size());
+        assertEquals(expectedSize, studyCommentResponse.getStudyCommentList().size());
     }
 
     @Test
@@ -316,11 +317,11 @@ class StudyCommentServiceTest extends TestConfig {
         studyCommentRepository.save(StudyCommentFixture.createDefaultStudyComment(userC.getId(), study2.getId()));
 
         // when
-        List<StudyCommentResponse> studyCommentResponse1 = studyCommentService.selectStudyCommentList(study1.getId(),  null, LIMIT);
-        List<StudyCommentResponse> studyCommentResponse2 = studyCommentService.selectStudyCommentList(study2.getId(),  null, LIMIT);
+        StudyCommentListAndCursorIdxResponse studyCommentResponse1 = studyCommentService.selectStudyCommentList(study1.getId(),  null, LIMIT);
+        StudyCommentListAndCursorIdxResponse studyCommentResponse2 = studyCommentService.selectStudyCommentList(study2.getId(),  null, LIMIT);
 
         // then
-        assertEquals(expectedStudy1CommentSize, studyCommentResponse1.size());
-        assertEquals(expectedStudy2CommentSize, studyCommentResponse2.size());
+        assertEquals(expectedStudy1CommentSize, studyCommentResponse1.getStudyCommentList().size());
+        assertEquals(expectedStudy2CommentSize, studyCommentResponse2.getStudyCommentList().size());
     }
 }

--- a/backend/src/test/java/com/example/backend/study/api/service/comment/study/StudyCommentServiceTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/service/comment/study/StudyCommentServiceTest.java
@@ -232,7 +232,7 @@ class StudyCommentServiceTest extends TestConfig {
         studyCommentRepository.saveAll(studyCommentList);
 
         // when
-        List<StudyCommentResponse> studyCommentListResponse = studyCommentService.selectStudyCommentList(user.getId(), cursorIdx, LIMIT);
+        List<StudyCommentResponse> studyCommentListResponse = studyCommentService.selectStudyCommentList(study.getId(), cursorIdx, LIMIT);
 
         for (StudyCommentResponse comment : studyCommentListResponse) {
             assertTrue(comment.getId() < cursorIdx);
@@ -251,7 +251,7 @@ class StudyCommentServiceTest extends TestConfig {
         studyCommentRepository.saveAll(studyCommentList);
 
         // when
-        List<StudyCommentResponse> studyCommentListResponse = studyCommentService.selectStudyCommentList(user.getId(), cursorIdx, LIMIT);
+        List<StudyCommentResponse> studyCommentListResponse = studyCommentService.selectStudyCommentList(study.getId(), cursorIdx, LIMIT);
 
         for (StudyCommentResponse comment : studyCommentListResponse) {
             assertTrue(comment.getId() < cursorIdx);
@@ -268,7 +268,7 @@ class StudyCommentServiceTest extends TestConfig {
         studyCommentRepository.saveAll(studyCommentList);
 
         // when
-        List<StudyCommentResponse> studyCommentListResponse = studyCommentService.selectStudyCommentList(user.getId(), null, LIMIT);
+        List<StudyCommentResponse> studyCommentListResponse = studyCommentService.selectStudyCommentList(study.getId(), null, LIMIT);
 
         assertEquals(LIMIT, studyCommentListResponse.size());
     }
@@ -288,9 +288,39 @@ class StudyCommentServiceTest extends TestConfig {
         studyCommentRepository.save(StudyCommentFixture.createDefaultStudyComment(userC.getId(), study.getId()));
 
         // when
-        List<StudyCommentResponse> studyCommentResponse = studyCommentService.selectStudyCommentList(userB.getId(),  null, LIMIT);
+        List<StudyCommentResponse> studyCommentResponse = studyCommentService.selectStudyCommentList(study.getId(),  null, LIMIT);
 
         // then
         assertEquals(expectedSize, studyCommentResponse.size());
+    }
+
+    @Test
+    void 특정_스터디_댓글들_조회_성공_테스트() {
+        // given
+        int expectedStudy1CommentSize = 4;
+        int expectedStudy2CommentSize = 3;
+
+        User userA = userRepository.save(UserFixture.generateAuthUserByPlatformId("A"));
+        User userB = userRepository.save(UserFixture.generateAuthUserByPlatformId("B"));
+        User userC = userRepository.save(UserFixture.generateAuthUserByPlatformId("C"));
+        StudyInfo study1 = studyInfoRepository.save(StudyInfoFixture.createDefaultPublicStudyInfo(userA.getId()));
+        StudyInfo study2 = studyInfoRepository.save(StudyInfoFixture.createDefaultPublicStudyInfo(userA.getId()));
+
+        studyCommentRepository.save(StudyCommentFixture.createDefaultStudyComment(userA.getId(), study1.getId()));
+        studyCommentRepository.save(StudyCommentFixture.createDefaultStudyComment(userB.getId(), study1.getId()));
+        studyCommentRepository.save(StudyCommentFixture.createDefaultStudyComment(userC.getId(), study1.getId()));
+        studyCommentRepository.save(StudyCommentFixture.createDefaultStudyComment(userC.getId(), study1.getId()));
+
+        studyCommentRepository.save(StudyCommentFixture.createDefaultStudyComment(userA.getId(), study2.getId()));
+        studyCommentRepository.save(StudyCommentFixture.createDefaultStudyComment(userB.getId(), study2.getId()));
+        studyCommentRepository.save(StudyCommentFixture.createDefaultStudyComment(userC.getId(), study2.getId()));
+
+        // when
+        List<StudyCommentResponse> studyCommentResponse1 = studyCommentService.selectStudyCommentList(study1.getId(),  null, LIMIT);
+        List<StudyCommentResponse> studyCommentResponse2 = studyCommentService.selectStudyCommentList(study2.getId(),  null, LIMIT);
+
+        // then
+        assertEquals(expectedStudy1CommentSize, studyCommentResponse1.size());
+        assertEquals(expectedStudy2CommentSize, studyCommentResponse2.size());
     }
 }

--- a/backend/src/test/java/com/example/backend/study/api/service/comment/study/StudyCommentServiceTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/service/comment/study/StudyCommentServiceTest.java
@@ -112,7 +112,7 @@ class StudyCommentServiceTest extends TestConfig {
                 StudyCommentFixture.createDefaultStudyCommentUpdateRequest(user.getId());
 
         // when
-        studyCommentService.updateStudyComment(studyCommentUpdateRequest, savedStudyComment.getId());
+        studyCommentService.updateStudyComment(studyCommentUpdateRequest, studyInfo.getId(),savedStudyComment.getId());
 
         // then
         Optional<StudyComment> studyComment = studyCommentRepository.findById(savedStudyComment.getId());
@@ -137,7 +137,7 @@ class StudyCommentServiceTest extends TestConfig {
 
         // when, then
         assertThrows(StudyCommentException.class, () -> {
-            studyCommentService.updateStudyComment(studyCommentUpdateRequest, invalidStudyCommentId);
+            studyCommentService.updateStudyComment(studyCommentUpdateRequest, studyInfo.getId(), invalidStudyCommentId);
         }, ExceptionMessage.STUDY_COMMENT_NOT_FOUND.getText());
     }
 
@@ -155,7 +155,7 @@ class StudyCommentServiceTest extends TestConfig {
 
         // when, then
         assertThrows(StudyCommentException.class, () -> {
-            studyCommentService.updateStudyComment(studyCommentUpdateRequest, savedStudyComment.getId());
+            studyCommentService.updateStudyComment(studyCommentUpdateRequest, studyInfo.getId(), savedStudyComment.getId());
         }, ExceptionMessage.STUDY_COMMENT_NOT_AUTHORIZED.getText());
     }
     @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

ex) #158

### Pull Request Type

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [x]  테스트 추가, 테스트 리팩토링
- [ ]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용

스터디 댓글 리스트 조회 api 구현
<img width="168" alt="스크린샷 2024-02-27 173611" src="https://github.com/DKU-Dgaja/gitudy/assets/102203336/b0df824f-ae85-49fd-89c7-98cf49ff385d">

## 💬 리뷰 요구사항

현재 원래 만들어져 있던 UserInfoResponse를 사용했는데 정보가 너무 많은가요??
댓글에는 유저 프로필이랑 이름정도만 들어가기 때문에 새로운 DTO를 생성해서 프로필 URL이랑 이름 정도만 넣어주는 방식으로 하는게 좋을까요??

피드백 부탁드립니다~~!
