### PR TITLE
[BE] feat(#213): 닉네임 중복체크 api

### DIFF
--- a/backend/src/main/java/com/example/backend/auth/api/controller/auth/AuthController.java
+++ b/backend/src/main/java/com/example/backend/auth/api/controller/auth/AuthController.java
@@ -1,6 +1,7 @@
 package com.example.backend.auth.api.controller.auth;
 
 import com.example.backend.auth.api.controller.auth.request.AuthRegisterRequest;
+import com.example.backend.auth.api.controller.auth.request.UserNameRequest;
 import com.example.backend.auth.api.controller.auth.request.UserUpdateRequest;
 import com.example.backend.auth.api.controller.auth.response.*;
 import com.example.backend.auth.api.service.auth.AuthService;
@@ -177,4 +178,13 @@ public class AuthController {
         return JsonResult.successOf("PushAlarmYn Update Success.");
     }
 
+
+    @ApiResponse(responseCode = "200", description = "닉네임 중복 검사 성공")
+    @PostMapping("/name")
+    public JsonResult<?> nickNameDuplicationCheck(@Valid @RequestBody UserNameRequest request) {
+
+        authService.nickNameDuplicationCheck(request);
+
+        return JsonResult.successOf("Nickname Duplication Check Success.");
+    }
 }

--- a/backend/src/main/java/com/example/backend/auth/api/controller/auth/AuthController.java
+++ b/backend/src/main/java/com/example/backend/auth/api/controller/auth/AuthController.java
@@ -180,7 +180,7 @@ public class AuthController {
 
 
     @ApiResponse(responseCode = "200", description = "닉네임 중복 검사 성공")
-    @PostMapping("/name")
+    @PostMapping("/check-nickname")
     public JsonResult<?> nickNameDuplicationCheck(@Valid @RequestBody UserNameRequest request) {
 
         authService.nickNameDuplicationCheck(request);

--- a/backend/src/main/java/com/example/backend/auth/api/controller/auth/request/UserNameRequest.java
+++ b/backend/src/main/java/com/example/backend/auth/api/controller/auth/request/UserNameRequest.java
@@ -1,0 +1,21 @@
+package com.example.backend.auth.api.controller.auth.request;
+
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserNameRequest {
+
+    @NotBlank(message = "이름은 공백일 수 없습니다.")
+    @Size(max = 6, message = "이름 6자 이내")
+    private String name;  // 이름
+
+}

--- a/backend/src/main/java/com/example/backend/auth/api/service/auth/AuthService.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/auth/AuthService.java
@@ -1,5 +1,6 @@
 package com.example.backend.auth.api.service.auth;
 
+import com.example.backend.auth.api.controller.auth.request.UserNameRequest;
 import com.example.backend.auth.api.controller.auth.response.AuthLoginResponse;
 import com.example.backend.auth.api.controller.auth.response.ReissueAccessTokenResponse;
 import com.example.backend.auth.api.controller.auth.response.UserInfoResponse;
@@ -283,5 +284,17 @@ public class AuthService {
                 });
 
         return UserInfoResponse.of(findUser);
+    }
+
+    // 닉네임 중복체크 메서드
+    public void nickNameDuplicationCheck(UserNameRequest request) {
+
+        boolean exists = userRepository.existsByName(request.getName());
+
+        if (exists) {
+            log.warn(">>>> {} : {} <<<<", request.getName(), ExceptionMessage.USER_NAME_DUPLICATION);
+            throw new UserException(ExceptionMessage.USER_NAME_DUPLICATION);
+        }
+
     }
 }

--- a/backend/src/main/java/com/example/backend/common/exception/ExceptionMessage.java
+++ b/backend/src/main/java/com/example/backend/common/exception/ExceptionMessage.java
@@ -36,6 +36,7 @@ public enum ExceptionMessage {
 
     // UserException
     USER_NOT_FOUND("데이터베이스에서 사용자를 찾을 수 없습니다."),
+    USER_NAME_DUPLICATION("중복된 이름입니다."),
 
     // AuthException
     AUTH_INVALID_REGISTER("잘못된 회원가입 요청입니다."),

--- a/backend/src/main/java/com/example/backend/domain/define/account/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/define/account/user/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     // select u from user u where u.platformId = :platformId and u.platformType = :platformType
     Optional<User> findByPlatformIdAndPlatformType(String platformId, UserPlatformType platformType);
 
+    // 같은 Name(닉네임)이 있는지 판별한다.
+    boolean existsByName(String name);
 }

--- a/backend/src/test/java/com/example/backend/auth/api/controller/auth/AuthControllerTest.java
+++ b/backend/src/test/java/com/example/backend/auth/api/controller/auth/AuthControllerTest.java
@@ -461,7 +461,7 @@ class AuthControllerTest extends TestConfig {
         doNothing().when(authService).nickNameDuplicationCheck(any(UserNameRequest.class));
 
         // when & then
-        mockMvc.perform(post("/auth/name")
+        mockMvc.perform(post("/auth/check-nickname")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
 
@@ -484,7 +484,7 @@ class AuthControllerTest extends TestConfig {
         doNothing().when(authService).nickNameDuplicationCheck(any(UserNameRequest.class));
 
         // when
-        mockMvc.perform(post("/auth/name")
+        mockMvc.perform(post("/auth/check-nickname")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
 
@@ -506,7 +506,7 @@ class AuthControllerTest extends TestConfig {
         doNothing().when(authService).nickNameDuplicationCheck(any(UserNameRequest.class));
 
         // when
-        mockMvc.perform(post("/auth/name")
+        mockMvc.perform(post("/auth/check-nickname")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
 

--- a/backend/src/test/java/com/example/backend/auth/api/controller/auth/AuthControllerTest.java
+++ b/backend/src/test/java/com/example/backend/auth/api/controller/auth/AuthControllerTest.java
@@ -2,6 +2,7 @@ package com.example.backend.auth.api.controller.auth;
 
 import com.example.backend.auth.TestConfig;
 import com.example.backend.auth.api.controller.auth.request.AuthRegisterRequest;
+import com.example.backend.auth.api.controller.auth.request.UserNameRequest;
 import com.example.backend.auth.api.controller.auth.request.UserUpdateRequest;
 import com.example.backend.auth.api.controller.auth.response.AuthLoginResponse;
 import com.example.backend.auth.api.controller.auth.response.UserInfoResponse;
@@ -10,6 +11,7 @@ import com.example.backend.auth.api.service.auth.request.AuthServiceRegisterRequ
 import com.example.backend.auth.api.service.auth.request.UserUpdateServiceRequest;
 import com.example.backend.auth.api.service.auth.response.UserUpdatePageResponse;
 import com.example.backend.auth.api.service.jwt.JwtService;
+import com.example.backend.auth.config.fixture.UserFixture;
 import com.example.backend.common.exception.ExceptionMessage;
 import com.example.backend.common.exception.auth.AuthException;
 import com.example.backend.common.utils.TokenUtil;
@@ -32,13 +34,13 @@ import java.util.Map;
 
 import static com.example.backend.domain.define.account.user.constant.UserPlatformType.GITHUB;
 import static com.example.backend.auth.config.fixture.UserFixture.*;
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SuppressWarnings("NonAsciiCharacters")
 class AuthControllerTest extends TestConfig {
@@ -448,6 +450,70 @@ class AuthControllerTest extends TestConfig {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.res_code").value(400))
                 .andExpect(jsonPath("$.res_msg").value(ExceptionMessage.UNAUTHORIZED_AUTHORITY.getText()))
+                .andDo(print());
+    }
+
+    @Test
+    void 닉네임_중복체크_테스트() throws Exception {
+        // given
+        UserNameRequest request = UserFixture.generateUserNameRequest("이정우");
+
+        doNothing().when(authService).nickNameDuplicationCheck(any(UserNameRequest.class));
+
+        // when & then
+        mockMvc.perform(post("/auth/name")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.res_code").value(200))
+                .andExpect(jsonPath("$.res_msg").value("OK"))
+                .andExpect(jsonPath("$.res_obj").value("Nickname Duplication Check Success."))
+                .andDo(print());
+    }
+
+    @Test
+    void 닉네임_중복체크_유효성_검증_실패_테스트1() throws Exception {
+        // given
+        String inValidName = "   ";
+        String expectedError = "name: 이름은 공백일 수 없습니다.";
+
+        UserNameRequest request = UserFixture.generateUserNameRequest(inValidName);
+
+        doNothing().when(authService).nickNameDuplicationCheck(any(UserNameRequest.class));
+
+        // when
+        mockMvc.perform(post("/auth/name")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(jsonPath("$.res_msg").value(expectedError))
+                .andDo(print());
+    }
+
+    @Test
+    void 닉네임_중복체크_유효성_검증_실패_테스트2() throws Exception {
+        // given
+        String inValidName = "이름은6자이내";
+        String expectedError = "name: 이름 6자 이내";
+
+        UserNameRequest request = UserFixture.generateUserNameRequest(inValidName);
+
+        doNothing().when(authService).nickNameDuplicationCheck(any(UserNameRequest.class));
+
+        // when
+        mockMvc.perform(post("/auth/name")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(jsonPath("$.res_msg").value(expectedError))
                 .andDo(print());
     }
 }

--- a/backend/src/test/java/com/example/backend/auth/api/service/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/example/backend/auth/api/service/auth/AuthServiceTest.java
@@ -373,6 +373,9 @@ class AuthServiceTest extends TestConfig {
 
         // when
         authService.nickNameDuplicationCheck(request);
+
+        // then
+        assertDoesNotThrow(() -> authService.nickNameDuplicationCheck(request));
     }
 
 }

--- a/backend/src/test/java/com/example/backend/auth/api/service/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/example/backend/auth/api/service/auth/AuthServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.backend.auth.api.service.auth;
 
 import com.example.backend.auth.TestConfig;
+import com.example.backend.auth.api.controller.auth.request.UserNameRequest;
 import com.example.backend.auth.api.controller.auth.response.AuthLoginResponse;
 import com.example.backend.auth.api.controller.auth.response.UserInfoResponse;
 import com.example.backend.auth.api.service.auth.request.AuthServiceRegisterRequest;
@@ -8,7 +9,10 @@ import com.example.backend.auth.api.service.auth.request.UserUpdateServiceReques
 import com.example.backend.auth.api.service.jwt.JwtService;
 import com.example.backend.auth.api.service.oauth.OAuthService;
 import com.example.backend.auth.api.service.oauth.response.OAuthResponse;
+import com.example.backend.auth.config.fixture.UserFixture;
+import com.example.backend.common.exception.ExceptionMessage;
 import com.example.backend.common.exception.auth.AuthException;
+import com.example.backend.common.exception.member.MemberException;
 import com.example.backend.common.exception.user.UserException;
 import com.example.backend.domain.define.account.user.SocialInfo;
 import com.example.backend.domain.define.account.user.User;
@@ -343,6 +347,32 @@ class AuthServiceTest extends TestConfig {
 
         // then
         assertFalse(updateUser2.isPushAlarmYn());
+    }
+
+    @Test
+    void 닉네임_중복체크_테스트_중복인경우() {
+        // given
+        userRepository.save(generateAuthUser());
+
+        UserNameRequest request = UserFixture.generateUserNameRequest("이름");
+
+        // then
+        UserException em = assertThrows(UserException.class, () -> {
+            authService.nickNameDuplicationCheck(request);
+        });
+
+        assertEquals(ExceptionMessage.USER_NAME_DUPLICATION.getText(), em.getMessage());
+    }
+
+    @Test
+    void 닉네임_중복체크_테스트_중복이아닌경우() {
+        // given
+        userRepository.save(generateAuthUser());
+
+        UserNameRequest request = UserFixture.generateUserNameRequest("이정우");
+
+        // when
+        authService.nickNameDuplicationCheck(request);
     }
 
 }

--- a/backend/src/test/java/com/example/backend/auth/config/fixture/UserFixture.java
+++ b/backend/src/test/java/com/example/backend/auth/config/fixture/UserFixture.java
@@ -1,5 +1,6 @@
 package com.example.backend.auth.config.fixture;
 
+import com.example.backend.auth.api.controller.auth.request.UserNameRequest;
 import com.example.backend.auth.api.service.oauth.response.OAuthResponse;
 import com.example.backend.domain.define.account.user.User;
 
@@ -82,4 +83,11 @@ public class UserFixture {
                 .githubId("구글아이디")
                 .build();
     }
+
+    public static UserNameRequest generateUserNameRequest(String name) {
+        return UserNameRequest.builder()
+                .name(name)
+                .build();
+    }
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#213 

### Pull Request Type

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [x]  테스트 추가, 테스트 리팩토링
- [ ]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용

닉네임 중복체크 api

## 💬 리뷰 요구사항

QueryDsl에서 exist 메서드 쓰는것보다 JPA의 exists 메서드를 사용
JPA exists메서드는 선택된 항이 하나라도 존재하면 즉시 처리를 멈추고 결과를 반환하는데
QueryDsl exist 메서드는 실제로 count() > 0 으로 실행한다고 해서 성능이슈..? ㅎㅎ

맞게 한건지 모르겠어요 ㅠㅠ 피드백 부탁드립니다..
