### PR TITLE
[BE] feat(#243): redis FCM token 저장 api 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/define/fcmToken/FcmToken.java
+++ b/backend/src/main/java/com/example/backend/domain/define/fcmToken/FcmToken.java
@@ -1,0 +1,24 @@
+package com.example.backend.domain.define.fcmToken;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@ToString
+@RedisHash(value = "fcm")
+@NoArgsConstructor
+@Builder
+public class FcmToken {
+    @Id
+    private Long userId;
+    private String fcmToken;
+
+    public FcmToken(Long userId, String fcmToken) {
+        this.userId = userId;
+        this.fcmToken = fcmToken;
+    }
+}

--- a/backend/src/main/java/com/example/backend/domain/define/fcmToken/repository/FcmTokenRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/define/fcmToken/repository/FcmTokenRepository.java
@@ -1,0 +1,7 @@
+package com.example.backend.domain.define.fcmToken.repository;
+
+import com.example.backend.domain.define.fcmToken.FcmToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface FcmTokenRepository extends CrudRepository<FcmToken, Long> {
+}

--- a/backend/src/main/java/com/example/backend/study/api/event/controller/FcmController.java
+++ b/backend/src/main/java/com/example/backend/study/api/event/controller/FcmController.java
@@ -1,0 +1,54 @@
+package com.example.backend.study.api.event.controller;
+
+import com.example.backend.domain.define.account.user.User;
+import com.example.backend.study.api.event.controller.request.FcmTokenSaveRequest;
+import com.example.backend.study.api.event.service.FcmService;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/fcm")
+public class FcmController {
+
+    private final FcmService fcmService;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    @ApiResponse(responseCode = "200", description = "FCM token 저장 성공")
+    @PostMapping("")
+    public void saveFcmToken(@AuthenticationPrincipal User userPrincipal,
+                             @RequestBody FcmTokenSaveRequest token) {
+        fcmService.saveFcmTokenRequest(userPrincipal, token);
+    }
+}

--- a/backend/src/main/java/com/example/backend/study/api/event/controller/FcmController.java
+++ b/backend/src/main/java/com/example/backend/study/api/event/controller/FcmController.java
@@ -1,5 +1,6 @@
 package com.example.backend.study.api.event.controller;
 
+import com.example.backend.common.response.JsonResult;
 import com.example.backend.domain.define.account.user.User;
 import com.example.backend.study.api.event.controller.request.FcmTokenSaveRequest;
 import com.example.backend.study.api.event.service.FcmService;
@@ -47,8 +48,9 @@ public class FcmController {
 
     @ApiResponse(responseCode = "200", description = "FCM token 저장 성공")
     @PostMapping("")
-    public void saveFcmToken(@AuthenticationPrincipal User userPrincipal,
-                             @RequestBody FcmTokenSaveRequest token) {
+    public JsonResult<?> saveFcmToken(@AuthenticationPrincipal User userPrincipal,
+                                      @RequestBody FcmTokenSaveRequest token) {
         fcmService.saveFcmTokenRequest(userPrincipal, token);
+        return JsonResult.successOf("FCM token save Success.");
     }
 }

--- a/backend/src/main/java/com/example/backend/study/api/event/controller/request/FcmTokenSaveRequest.java
+++ b/backend/src/main/java/com/example/backend/study/api/event/controller/request/FcmTokenSaveRequest.java
@@ -1,0 +1,14 @@
+package com.example.backend.study.api.event.controller.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class FcmTokenSaveRequest {
+
+    private String token;             // 토큰 한개를 가져올 때
+}
+

--- a/backend/src/main/java/com/example/backend/study/api/event/controller/request/FcmTokenSaveRequest.java
+++ b/backend/src/main/java/com/example/backend/study/api/event/controller/request/FcmTokenSaveRequest.java
@@ -1,14 +1,15 @@
 package com.example.backend.study.api.event.controller.request;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class FcmTokenSaveRequest {
 
     private String token;             // 토큰 한개를 가져올 때
 }
-

--- a/backend/src/main/java/com/example/backend/study/api/event/service/FcmService.java
+++ b/backend/src/main/java/com/example/backend/study/api/event/service/FcmService.java
@@ -1,0 +1,85 @@
+package com.example.backend.study.api.event.service;
+
+import com.example.backend.common.exception.ExceptionMessage;
+import com.example.backend.common.exception.user.UserException;
+import com.example.backend.domain.define.account.user.User;
+import com.example.backend.domain.define.account.user.repository.UserRepository;
+import com.example.backend.domain.define.fcmToken.FcmToken;
+import com.example.backend.domain.define.fcmToken.repository.FcmTokenRepository;
+import com.example.backend.study.api.event.controller.request.FcmTokenSaveRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class FcmService {
+
+
+
+    private final UserRepository userRepository;
+
+    private final FcmTokenRepository fcmTokenRepository;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    @Transactional
+    public void saveFcmTokenRequest(User userPrincipal, FcmTokenSaveRequest token) {
+
+        User user = userRepository.findByPlatformIdAndPlatformType(userPrincipal.getPlatformId(), userPrincipal.getPlatformType()).orElseThrow(() -> {
+            log.warn(">>>> {},{} : {} <<<<", userPrincipal.getPlatformId(), userPrincipal.getPlatformType(), ExceptionMessage.USER_NOT_FOUND);
+            return new UserException(ExceptionMessage.USER_NOT_FOUND);
+        });
+
+        saveRefreshToken(FcmToken.builder()
+                .userId(user.getId())
+                .fcmToken(token.getToken())
+                .build());
+    }
+
+    // FCM 토큰 저장 메서드
+    public void saveRefreshToken(FcmToken fcmToken) {
+        FcmToken savedToken = fcmTokenRepository.save(fcmToken);
+        log.info(">>>> FCM Token register : {}", savedToken.getFcmToken());
+    }
+}

--- a/backend/src/test/java/com/example/backend/domain/define/fcmToken/repository/FcmTokenRepositoryTest.java
+++ b/backend/src/test/java/com/example/backend/domain/define/fcmToken/repository/FcmTokenRepositoryTest.java
@@ -1,0 +1,45 @@
+package com.example.backend.domain.define.fcmToken.repository;
+
+import com.example.backend.auth.TestConfig;
+import com.example.backend.auth.config.fixture.UserFixture;
+import com.example.backend.domain.define.account.user.User;
+import com.example.backend.domain.define.account.user.repository.UserRepository;
+import com.example.backend.domain.define.fcmToken.FcmToken;
+import com.example.backend.domain.define.refreshToken.RefreshToken;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FcmTokenRepositoryTest extends TestConfig {
+    @Autowired
+    private FcmTokenRepository fcmTokenRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @AfterEach
+    void tearDown() {
+        fcmTokenRepository.deleteAll();
+        userRepository.deleteAllInBatch();
+    }
+    @Test
+    @DisplayName("FcmToken을 저장할 수 있다.")
+    void redisLoginStateSave() {
+        // given
+        User user = userRepository.save(UserFixture.generateAuthUser());
+        FcmToken fcmToken = fcmTokenRepository.save(FcmToken.builder()
+                .userId(user.getId())
+                .fcmToken("fcmToken")
+                .build());
+
+        // when
+        FcmToken savedFcmToken = fcmTokenRepository.findById(fcmToken.getUserId()).get();
+
+        // then
+        assertThat(fcmToken.getUserId()).isEqualTo(savedFcmToken.getUserId());
+        assertThat(fcmToken.getFcmToken()).isEqualTo(savedFcmToken.getFcmToken());
+    }
+}

--- a/backend/src/test/java/com/example/backend/study/api/event/controller/FcmControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/event/controller/FcmControllerTest.java
@@ -1,0 +1,78 @@
+package com.example.backend.study.api.event.controller;
+
+import com.example.backend.auth.TestConfig;
+import com.example.backend.auth.api.service.jwt.JwtService;
+import com.example.backend.common.utils.TokenUtil;
+import com.example.backend.domain.define.account.user.User;
+import com.example.backend.domain.define.account.user.repository.UserRepository;
+import com.example.backend.study.api.event.controller.request.FcmTokenSaveRequest;
+import com.example.backend.study.api.event.service.FcmService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static com.example.backend.auth.config.fixture.UserFixture.generateAuthUser;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SuppressWarnings("NonAsciiCharacters")
+class FcmControllerTest extends TestConfig {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JwtService jwtService;
+
+    @MockBean
+    private FcmService fcmService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void FCM_token_저장_테스트() throws Exception {
+        // given
+        User savedUser = userRepository.save(generateAuthUser());
+
+        FcmTokenSaveRequest token = FcmTokenSaveRequest.builder()
+                .token("token")
+                .build();
+
+        Map<String, String> map = TokenUtil.createTokenMap(savedUser);
+        String accessToken = jwtService.generateAccessToken(map, savedUser);
+        String refreshToken = jwtService.generateRefreshToken(map, savedUser);
+
+
+        // when
+        doNothing().when(fcmService).saveFcmTokenRequest(any(User.class), any(FcmTokenSaveRequest.class));
+
+        // then
+        mockMvc.perform(post("/fcm")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
+                        .content(objectMapper.writeValueAsString(token)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.res_code").value(200))
+                .andExpect(jsonPath("$.res_msg").value("OK"))
+                .andExpect(jsonPath("$.res_obj").value("FCM token save Success."))
+                .andDo(print());
+    }
+}

--- a/backend/src/test/java/com/example/backend/study/api/event/service/FcmServiceTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/event/service/FcmServiceTest.java
@@ -1,0 +1,48 @@
+package com.example.backend.study.api.event.service;
+
+import com.example.backend.auth.TestConfig;
+import com.example.backend.domain.define.account.user.User;
+import com.example.backend.domain.define.account.user.repository.UserRepository;
+import com.example.backend.domain.define.fcmToken.repository.FcmTokenRepository;
+import com.example.backend.study.api.event.controller.request.FcmTokenSaveRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.example.backend.auth.config.fixture.UserFixture.generateAuthUser;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings("NonAsciiCharacters")
+class FcmServiceTest extends TestConfig {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FcmService fcmService;
+
+    @Autowired
+    private FcmTokenRepository fcmTokenRepository;
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAllInBatch();
+        fcmTokenRepository.deleteAll();
+    }
+
+    @Test
+    void FCM_token_저장_테스트() {
+        // given
+        String fcmToken = "FCM_token";
+        User user = userRepository.save(generateAuthUser());
+
+        FcmTokenSaveRequest token = FcmTokenSaveRequest.builder()
+                .token(fcmToken)
+                .build();
+        // when
+        fcmService.saveFcmTokenRequest(user, token);
+
+        // then
+        assertEquals(fcmTokenRepository.findById(user.getId()).get().getFcmToken(), fcmToken);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

ex) #243

### Pull Request Type

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용

### redis를 활용한  FCM token 저장 api 구현

key : userId
value : FCM token

* #244와 충돌을 우려해 빈칸이 많습니다.
* 패키지 구조 토의 후 구조 확정되면 controller, service test 추가해서 올리겠습니다.


### 데이터베이스 저장 확인
<img width="877" alt="스크린샷 2024-03-27 120312" src="https://github.com/DKU-Dgaja/gitudy/assets/102203336/758733b2-875d-4f62-afe0-c85eabcee6e9">


## 💬 리뷰 요구사항

리뷰 부탁드립니다!

