### PR TITLE
[AN] feat(#334): 마이스터디 메인 페이지 내 커밋 컨벤션 정보 api 호출 기능 구현

### DIFF
--- a/android/gitudy/data/src/main/java/com/takseha/data/api/gitudy/study/GitudyStudyApi.kt
+++ b/android/gitudy/data/src/main/java/com/takseha/data/api/gitudy/study/GitudyStudyApi.kt
@@ -3,6 +3,7 @@ package com.takseha.data.api.gitudy.study
 import com.takseha.data.dto.feed.MakeStudyRequest
 import com.takseha.data.dto.feed.MakeStudyResponse
 import com.takseha.data.dto.feed.StudyListResponse
+import com.takseha.data.dto.mystudy.ConventionResponse
 import com.takseha.data.dto.mystudy.MakeTodoRequest
 import com.takseha.data.dto.mystudy.MakeTodoResponse
 import com.takseha.data.dto.mystudy.MyStudyResponse
@@ -67,4 +68,12 @@ interface GitudyStudyApi {
         @Path("studyInfoId") studyInfoId: Int,
         @Body request: SetConventionRequest
     ): Response<SetConventionResponse>
+
+    @GET("/study/{studyInfoId}/convention")
+    suspend fun getConvention(
+        @Header("Authorization") bearerToken: String,
+        @Path("studyInfoId") studyInfoId: Int,
+        @Query("cursorIdx") cursorIdx: Int?,
+        @Query("limit") limit: Int
+    ): Response<ConventionResponse>
 }

--- a/android/gitudy/data/src/main/java/com/takseha/data/dto/mystudy/ConventionResponse.kt
+++ b/android/gitudy/data/src/main/java/com/takseha/data/dto/mystudy/ConventionResponse.kt
@@ -2,6 +2,7 @@ package com.takseha.data.dto.mystudy
 
 
 import com.google.gson.annotations.SerializedName
+import java.io.Serializable
 
 data class ConventionResponse(
     @SerializedName("res_code")
@@ -32,4 +33,4 @@ data class StudyConvention(
     val name: String,
     @SerializedName("study_info_id")
     val studyInfoId: Int
-)
+) : Serializable

--- a/android/gitudy/data/src/main/java/com/takseha/data/dto/mystudy/ConventionResponse.kt
+++ b/android/gitudy/data/src/main/java/com/takseha/data/dto/mystudy/ConventionResponse.kt
@@ -1,0 +1,35 @@
+package com.takseha.data.dto.mystudy
+
+
+import com.google.gson.annotations.SerializedName
+
+data class ConventionResponse(
+    @SerializedName("res_code")
+    val resCode: Int,
+    @SerializedName("res_msg")
+    val resMsg: String,
+    @SerializedName("res_obj")
+    val conventionInfo: ConventionInfo
+)
+
+data class ConventionInfo(
+    @SerializedName("cursor_idx")
+    val cursorIdx: Int,
+    @SerializedName("study_convention_list")
+    val studyConventionList: List<StudyConvention>
+)
+
+data class StudyConvention(
+    @SerializedName("active")
+    val active: Boolean,
+    @SerializedName("content")
+    val content: String,
+    @SerializedName("convention_id")
+    val conventionId: Int,
+    @SerializedName("description")
+    val description: String,
+    @SerializedName("name")
+    val name: String,
+    @SerializedName("study_info_id")
+    val studyInfoId: Int
+)

--- a/android/gitudy/data/src/main/java/com/takseha/data/repository/study/GitudyStudyRepository.kt
+++ b/android/gitudy/data/src/main/java/com/takseha/data/repository/study/GitudyStudyRepository.kt
@@ -50,4 +50,9 @@ class GitudyStudyRepository {
         studyInfoId: Int,
         request: SetConventionRequest
     ) = client.setConvention(bearerToken, studyInfoId, request)
+
+    suspend fun getConvention(
+        bearerToken: String,
+        studyInfoId: Int,
+    ) = client.getTodoList(bearerToken, studyInfoId, null, 1)
 }

--- a/android/gitudy/data/src/main/java/com/takseha/data/repository/study/GitudyStudyRepository.kt
+++ b/android/gitudy/data/src/main/java/com/takseha/data/repository/study/GitudyStudyRepository.kt
@@ -54,5 +54,5 @@ class GitudyStudyRepository {
     suspend fun getConvention(
         bearerToken: String,
         studyInfoId: Int,
-    ) = client.getTodoList(bearerToken, studyInfoId, null, 1)
+    ) = client.getConvention(bearerToken, studyInfoId, null, 1)
 }

--- a/android/gitudy/presentation/src/main/java/com/takseha/presentation/ui/home/MainHomeFragment.kt
+++ b/android/gitudy/presentation/src/main/java/com/takseha/presentation/ui/home/MainHomeFragment.kt
@@ -55,6 +55,13 @@ class MainHomeFragment : Fragment() {
             viewModel.apply {
                 uiState.collectLatest {
                     setUserInfo(it)
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.apply {
+                myStudyState.collectLatest {
                     setMyStudyList(it.myStudiesWithTodo)
                 }
             }

--- a/android/gitudy/presentation/src/main/java/com/takseha/presentation/ui/mystudy/CommitConventionActivity.kt
+++ b/android/gitudy/presentation/src/main/java/com/takseha/presentation/ui/mystudy/CommitConventionActivity.kt
@@ -6,6 +6,7 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.view.View
 import androidx.activity.viewModels
+import com.takseha.data.dto.mystudy.StudyConvention
 import com.takseha.presentation.R
 import com.takseha.presentation.databinding.ActivityCommitConventionBinding
 import com.takseha.presentation.viewmodel.mystudy.CommitConventionViewModel
@@ -20,12 +21,15 @@ class CommitConventionActivity : AppCompatActivity() {
         setBinding()
 
         val studyInfoId = intent.getIntExtra("studyInfoId", 0)
+        val conventionInfo = intent.getSerializableExtra("conventionInfo") as StudyConvention
 
         with(binding) {
-            var convention = ""
-            var content = ""
-            var description = ""
-            var active = false // 추후 커밋 컨벤션 불러오기 api 호출 후 맞게 적용
+            var convention = conventionInfo.name
+            var content = conventionInfo.content
+            var description = conventionInfo.description
+            var active = conventionInfo.active
+
+            setInitConvention(convention, content, description, active)
 
             conventionEditText.addTextChangedListener(object : TextWatcher {
                 override fun beforeTextChanged(
@@ -94,11 +98,31 @@ class CommitConventionActivity : AppCompatActivity() {
                 active = true
                 viewModel.setConvention(studyInfoId, convention, description, content, active)
 
-                isNotConventionText.visibility = View.GONE
-                isConventionText.visibility = View.VISIBLE
+                isConventionActive(active)
 
                 saveBtn.isEnabled = false
                 saveBtn.text = "저장 완료"
+            }
+        }
+    }
+
+    private fun setInitConvention(convention: String, content: String, description: String, active: Boolean) {
+        with(binding) {
+            conventionEditText.setText(convention)
+            contentEditText.setText(content)
+            descriptionEditText.setText(description)
+            isConventionActive(active)
+        }
+    }
+
+    private fun isConventionActive(active: Boolean) {
+        with(binding) {
+            if(active) {
+                isNotConventionText.visibility = View.GONE
+                isConventionText.visibility = View.VISIBLE
+            } else {
+                isNotConventionText.visibility = View.VISIBLE
+                isConventionText.visibility = View.GONE
             }
         }
     }

--- a/android/gitudy/presentation/src/main/java/com/takseha/presentation/ui/mystudy/MyStudyHomeFragment.kt
+++ b/android/gitudy/presentation/src/main/java/com/takseha/presentation/ui/mystudy/MyStudyHomeFragment.kt
@@ -42,8 +42,8 @@ class MyStudyHomeFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.uiState.collectLatest {
-                    setMyStudyList(it.myStudiesWithTodo)
+            viewModel.myStudyState.collectLatest {
+                setMyStudyList(it.myStudiesWithTodo)
             }
         }
     }

--- a/android/gitudy/presentation/src/main/java/com/takseha/presentation/ui/mystudy/MyStudyMainActivity.kt
+++ b/android/gitudy/presentation/src/main/java/com/takseha/presentation/ui/mystudy/MyStudyMainActivity.kt
@@ -60,6 +60,7 @@ class MyStudyMainActivity : AppCompatActivity() {
             conventionLayout.setOnClickListener {
                 val intent = Intent(this@MyStudyMainActivity, CommitConventionActivity::class.java)
                 intent.putExtra("studyInfoId", studyInfoId)
+                intent.putExtra("conventionInfo", viewModel.uiState.value.conventionInfo)
                 startActivity(intent)
             }
         }
@@ -72,7 +73,6 @@ class MyStudyMainActivity : AppCompatActivity() {
                 setMyStudyInfo(studyInfoId, studyImgColor, it.myStudyInfo)
                 setTodoInfo(it.todoInfo)
                 setConventionInfo(it.conventionInfo)
-                Log.d("MyStudyMainActivity", firstTodoLink)
             }
         }
     }

--- a/android/gitudy/presentation/src/main/java/com/takseha/presentation/ui/mystudy/MyStudyMainActivity.kt
+++ b/android/gitudy/presentation/src/main/java/com/takseha/presentation/ui/mystudy/MyStudyMainActivity.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.lifecycleScope
 import com.takseha.data.dto.feed.StudyPeriod
 import com.takseha.data.dto.feed.StudyStatus
 import com.takseha.data.dto.mystudy.MyStudyInfo
+import com.takseha.data.dto.mystudy.StudyConvention
 import com.takseha.data.dto.mystudy.Todo
 import com.takseha.presentation.R
 import com.takseha.presentation.databinding.ActivityMyStudyMainBinding
@@ -70,6 +71,7 @@ class MyStudyMainActivity : AppCompatActivity() {
             viewModel.uiState.collectLatest {
                 setMyStudyInfo(studyInfoId, studyImgColor, it.myStudyInfo)
                 setTodoInfo(it.todoInfo)
+                setConventionInfo(it.conventionInfo)
                 Log.d("MyStudyMainActivity", firstTodoLink)
             }
         }
@@ -114,6 +116,20 @@ class MyStudyMainActivity : AppCompatActivity() {
                     ))
                 }
                 firstTodoLink = todoInfo.todoLink
+            }
+        }
+    }
+
+    private fun setConventionInfo(conventionInfo: StudyConvention?) {
+        with(binding) {
+            if (conventionInfo == null) {
+                commitConventionText.visibility = View.GONE
+                noConventionAlarm.visibility = View.VISIBLE
+            } else {
+                commitConventionText.visibility = View.VISIBLE
+                noConventionAlarm.visibility = View.GONE
+
+                commitConvention.text = conventionInfo.name
             }
         }
     }

--- a/android/gitudy/presentation/src/main/java/com/takseha/presentation/viewmodel/home/MainHomeViewModel.kt
+++ b/android/gitudy/presentation/src/main/java/com/takseha/presentation/viewmodel/home/MainHomeViewModel.kt
@@ -35,6 +35,9 @@ class MainHomeViewModel(application: Application) : AndroidViewModel(application
     private val _uiState = MutableStateFlow(MainHomeUserInfoUiState())
     val uiState = _uiState.asStateFlow()
 
+    private val _myStudyState = MutableStateFlow(MainHomeMyStudyUiState())
+    val myStudyState = _myStudyState.asStateFlow()
+
     // stateflow로 바꾸는 거도 고민해보기~ 초기값 null 설정 가정
     private var _cursorIdxRes = MutableLiveData<Long?>()
     val cursorIdxRes: LiveData<Long?>
@@ -153,7 +156,7 @@ class MainHomeViewModel(application: Application) : AndroidViewModel(application
                         MyStudyWithTodo(backgroundColorList[study.id % 4], study, null, null, TodoStatus.TODO_EMPTY, null)
                     }
                 }
-                _uiState.update {
+                _myStudyState.update {
                     it.copy(
                         myStudiesWithTodo = studiesWithTodo
                     )
@@ -249,5 +252,8 @@ data class MainHomeUserInfoUiState(
     var progressScore: Int = 0,
     var progressMax: Int = 15,
     var characterImgSrc: Int = R.drawable.character_bebe_to_15,
-    var myStudiesWithTodo: List<MyStudyWithTodo> = listOf()
 ) : Serializable
+
+data class MainHomeMyStudyUiState(
+    var myStudiesWithTodo: List<MyStudyWithTodo> = listOf()
+)

--- a/android/gitudy/presentation/src/main/java/com/takseha/presentation/viewmodel/mystudy/CommitConventionViewModel.kt
+++ b/android/gitudy/presentation/src/main/java/com/takseha/presentation/viewmodel/mystudy/CommitConventionViewModel.kt
@@ -17,6 +17,10 @@ class CommitConventionViewModel(application: Application) : AndroidViewModel(app
     private var gitudyStudyRepository: GitudyStudyRepository = GitudyStudyRepository()
     private val prefs = SP(getApplication())
 
+    val bearerToken = "Bearer ${prefs.loadPref(SPKey.ACCESS_TOKEN, "0")} ${
+        prefs.loadPref(SPKey.REFRESH_TOKEN, "0")
+    }"
+
     fun setConvention(
         studyInfoId: Int,
         name: String,
@@ -24,9 +28,6 @@ class CommitConventionViewModel(application: Application) : AndroidViewModel(app
         content: String,
         active: Boolean
     ) = viewModelScope.launch {
-        val bearerToken = "Bearer ${prefs.loadPref(SPKey.ACCESS_TOKEN, "0")} ${
-            prefs.loadPref(SPKey.REFRESH_TOKEN, "0")
-        }"
         val request = SetConventionRequest(active, content, description, name)
         Log.d("CommitConventionViewModel", request.toString())
 

--- a/android/gitudy/presentation/src/main/res/layout/activity_commit_convention.xml
+++ b/android/gitudy/presentation/src/main/res/layout/activity_commit_convention.xml
@@ -55,7 +55,7 @@
         android:layout_height="wrap_content"
         android:layout_marginLeft="6dp"
         android:layout_marginTop="26dp"
-        android:text="적용"
+        android:text="적용 중"
         android:textColor="@color/BASIC_BLUE"
         android:visibility="gone"
         app:layout_constraintStart_toEndOf="@+id/convientionTitle"

--- a/android/gitudy/presentation/src/main/res/layout/activity_my_study_main.xml
+++ b/android/gitudy/presentation/src/main/res/layout/activity_my_study_main.xml
@@ -352,6 +352,20 @@
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent" />
 
+                    <TextView
+                        android:id="@+id/noConventionAlarm"
+                        style="@style/B6_1"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:layout_marginLeft="12dp"
+                        android:text="@string/no_commit_convention"
+                        android:textColor="@color/BASIC_BLUE"
+                        android:visibility="gone"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintStart_toEndOf="@+id/commitConventionImg"
+                        app:layout_constraintTop_toTopOf="parent" />
+
                     <LinearLayout
                         android:id="@+id/commitConventionText"
                         android:layout_width="wrap_content"
@@ -379,7 +393,6 @@
                             android:layout_height="wrap_content"
                             android:layout_marginRight="4dp"
                             android:layout_marginTop="2dp"
-                            android:text="@string/commit_convention"
                             android:textColor="@color/BASIC_BLUE" />
 
 

--- a/android/gitudy/presentation/src/main/res/values/strings.xml
+++ b/android/gitudy/presentation/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="to_do_deadline_date">%d.%d.%d</string>
     <string name="to_do_add">새로운 TO-DO를\n추가하시겠습니까?</string>
     <string name="comment">우리 2월까지 마무리 할 수 있겠지?</string>
+    <string name="no_commit_convention">커밋 컨벤션을 등록해 주세요!</string>
     <string name="commit_convention">ex) [문제 플랫폼]#문제번호:사용언어</string>
     <string name="commit_convention_content">ex) ^\\[[A-Z]+\\]#\\d+\\:[\\w+]+</string>
     <string name="commit_convention_description">ex) [BOJ]#1234:Kotlin, [PRO]#1234:C++</string>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#334

### Pull Request Type

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용

마이스터디 메인 페이지 내에서 기등록된 커밋 컨벤션 정보를 나타내는 기능 구현
호출한 커밋 컨벤션 정보를 커밋 컨벤션 상세페이지로 전달하여 화면에 표시하는 기능 구현
- /study/{studyInfoId}/convention api 호출


https://github.com/DKU-Dgaja/gitudy/assets/86196342/abbb2395-d9d3-452f-aa37-36aa0d9bf846


## 💬 리뷰 요구사항
