### PR TITLE
[BE] Refactor(#403): 응답 객체 구조 변경

### DIFF
--- a/backend/src/main/java/com/example/backend/BackendApplication.java
+++ b/backend/src/main/java/com/example/backend/BackendApplication.java
@@ -9,7 +9,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @SpringBootApplication
 @ConfigurationPropertiesScan("com.example.backend.auth.config")
 @EnableJpaAuditing // JPA Auditing 기능 활성화 - BaseEntity
-
 @EnableAsync // event 비동기
 public class BackendApplication {
 

--- a/backend/src/main/java/com/example/backend/auth/api/controller/auth/AuthController.java
+++ b/backend/src/main/java/com/example/backend/auth/api/controller/auth/AuthController.java
@@ -14,6 +14,8 @@ import com.example.backend.auth.api.service.auth.response.UserUpdatePageResponse
 import com.example.backend.auth.api.service.oauth.OAuthService;
 import com.example.backend.auth.api.service.state.LoginStateService;
 import com.example.backend.common.exception.ExceptionMessage;
+import com.example.backend.common.exception.auth.AuthException;
+import com.example.backend.common.exception.jwt.JwtException;
 import com.example.backend.common.exception.oauth.OAuthException;
 import com.example.backend.common.response.JsonResult;
 import com.example.backend.domain.define.account.user.User;
@@ -21,7 +23,6 @@ import com.example.backend.domain.define.account.user.constant.UserPlatformType;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import jakarta.security.auth.message.AuthException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,7 +53,6 @@ public class AuthController {
 
         // OAuth 사용하여 각 플랫폼의 로그인 페이지 URL을 가져와서 state 주입
         List<AuthLoginPageResponse> loginPages = oAuthService.loginPage(loginState);
-
 
         return JsonResult.successOf(loginPages);
     }
@@ -86,7 +86,7 @@ public class AuthController {
             return JsonResult.successOf("로그아웃 되었습니다.");
         } else {
             log.warn(">>>> Invalid Header Access : {}", ExceptionMessage.JWT_INVALID_HEADER.getText());
-            return JsonResult.failOf(ExceptionMessage.JWT_INVALID_HEADER.getText());
+            throw new JwtException(ExceptionMessage.JWT_INVALID_HEADER);
         }
 
     }
@@ -102,7 +102,7 @@ public class AuthController {
             return JsonResult.successOf(reissueResponse);
         } else {
             log.warn(">>>> Invalid Header Access : {}", ExceptionMessage.JWT_INVALID_HEADER.getText());
-            return JsonResult.failOf(ExceptionMessage.JWT_INVALID_HEADER.getText());
+            throw new JwtException(ExceptionMessage.JWT_INVALID_HEADER);
         }
     }
 
@@ -112,7 +112,7 @@ public class AuthController {
 
         if (user.getRole() == UNAUTH) {
             log.error(">>>> {} <<<<", ExceptionMessage.UNAUTHORIZED_AUTHORITY);
-            return JsonResult.failOf(ExceptionMessage.UNAUTHORIZED_AUTHORITY.getText());
+            throw new AuthException(ExceptionMessage.UNAUTHORIZED_AUTHORITY);
         }
 
         UserInfoResponse userInfoResponse = authService.getUserByInfo(user.getPlatformId(), user.getPlatformType());

--- a/backend/src/main/java/com/example/backend/auth/config/security/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/backend/auth/config/security/filter/JwtAuthenticationFilter.java
@@ -164,10 +164,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private void jwtExceptionHandler(HttpServletResponse response, ExceptionMessage message) throws IOException {
         log.error(">>>> [ JWT 토큰 인증 중 Error 발생 : {} ] <<<<", message.getText());
 
-        response.setStatus(HttpStatus.OK.value());
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.setCharacterEncoding("utf-8");
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.getWriter().write(objectMapper.writeValueAsString(JsonResult.failOfUnauthorized(message.getText())));
+        response.getWriter().write(objectMapper.writeValueAsString(JsonResult.failOf(message.getText())));
     }
 
 }

--- a/backend/src/main/java/com/example/backend/common/exception/ExceptionMessage.java
+++ b/backend/src/main/java/com/example/backend/common/exception/ExceptionMessage.java
@@ -33,16 +33,14 @@ public enum ExceptionMessage {
   
     // AuthException
     UNAUTHORIZED_AUTHORITY("현재 요청한 작업을 수행할 권한이 없습니다."),
-
-    // UserException
-    USER_NOT_FOUND("데이터베이스에서 사용자를 찾을 수 없습니다."),
-    USER_NAME_DUPLICATION("중복된 이름입니다."),
-
-    // AuthException
     AUTH_INVALID_REGISTER("잘못된 회원가입 요청입니다."),
     AUTH_DUPLICATE_UNAUTH_REGISTER("중복된 회원가입 요청입니다."),
     AUTH_NOT_FOUND("계정 정보를 찾을 수 없습니다."),
     AUTH_DELETE_FAIL("계정 삭제에 실패했습니다."),
+
+    // UserException
+    USER_NOT_FOUND("데이터베이스에서 사용자를 찾을 수 없습니다."),
+    USER_NAME_DUPLICATION("중복된 이름입니다."),
 
     // CommitException
     COMMIT_NOT_FOUND("커밋 정보를 찾을 수 없습니다."),

--- a/backend/src/main/java/com/example/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/example/backend/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.example.backend.common.exception;
 
 import com.example.backend.common.exception.jwt.JwtException;
 import com.example.backend.common.response.JsonResult;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -16,40 +18,45 @@ public class GlobalExceptionHandler {
         데이터 바인딩 중 발생하는 에러 BindException 처리
      */
     @ExceptionHandler(BindException.class)
-    public JsonResult bindException(BindException e) {
-        return JsonResult.failOf(
+    public ResponseEntity<JsonResult> bindException(BindException e) {
+        JsonResult error = JsonResult.failOf(
                 e.getBindingResult()
                         .getFieldErrors()
                         .stream()
                         .map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
                         .collect(Collectors.joining(", "))
         );
+
+        return ResponseEntity.badRequest().body(error);
     }
 
     /*
         @Valid 어노테이션을 사용한 DTO의 유효성 검사에서 예외가 발생한 경우
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public JsonResult handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
-        return JsonResult.failOf(
+    public ResponseEntity<JsonResult> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        JsonResult error = JsonResult.failOf(
                 e.getBindingResult()
                         .getFieldErrors()
                         .stream()
                         .map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
                         .collect(Collectors.joining(", "))
         );
+
+        return ResponseEntity.badRequest().body(error);
     }
 
     /*
         JWT 관련 예외 처리
      */
     @ExceptionHandler(com.example.backend.common.exception.jwt.JwtException.class)
-    public JsonResult<Exception> handleJwtException(JwtException e) {
-        return JsonResult.failOfUnauthorized(e.getMessage());
+    public ResponseEntity<JsonResult> handleJwtException(JwtException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(JsonResult.failOf(e.getMessage()));
+
     }
 
     @ExceptionHandler(Exception.class)
-    public JsonResult<Exception> exception(Exception e) {
-        return JsonResult.failOf(e.getMessage());
+    public ResponseEntity<JsonResult> exception(Exception e) {
+        return ResponseEntity.badRequest().body(JsonResult.failOf(e.getMessage()));
     }
 }

--- a/backend/src/main/java/com/example/backend/common/response/JsonResult.java
+++ b/backend/src/main/java/com/example/backend/common/response/JsonResult.java
@@ -8,13 +8,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 @NoArgsConstructor
 public class JsonResult<T> {
-    private Integer resCode;
     private T resObj;
     private String resMsg;
 
     @Builder
-    public JsonResult(Integer resCode, T resObj, String resMsg) {
-        this.resCode = resCode;
+    public JsonResult(T resObj, String resMsg) {
         this.resObj = resObj;
         this.resMsg = resMsg;
     }
@@ -24,14 +22,12 @@ public class JsonResult<T> {
      */
     public static JsonResult successOf() {
         return JsonResult.builder()
-                .resCode(HttpStatus.OK.value())
                 .resMsg(HttpStatus.OK.getReasonPhrase())
                 .build();
     }
 
     public static <T> JsonResult successOf(T resObj) {
         return JsonResult.builder()
-                .resCode(HttpStatus.OK.value())
                 .resObj(resObj)
                 .resMsg(HttpStatus.OK.getReasonPhrase())
                 .build();
@@ -40,33 +36,8 @@ public class JsonResult<T> {
     /*
         실패 응답 객체 생성 메서드 - static
      */
-    public static JsonResult failOf() {
-        return JsonResult.builder()
-                .resCode(HttpStatus.BAD_REQUEST.value())
-                .resMsg(HttpStatus.BAD_REQUEST.getReasonPhrase())
-                .build();
-    }
-
     public static <T> JsonResult failOf(String resMsg) {
         return JsonResult.builder()
-                .resCode(HttpStatus.BAD_REQUEST.value())
-                .resMsg(resMsg)
-                .build();
-    }
-
-    /*
-        토큰 관련 실패 응답 객체 생성 메서드 - static
-     */
-    public static JsonResult failOfUnauthorized() {
-        return JsonResult.builder()
-                .resCode(HttpStatus.UNAUTHORIZED.value())
-                .resMsg(HttpStatus.UNAUTHORIZED.getReasonPhrase())
-                .build();
-    }
-
-    public static <T> JsonResult failOfUnauthorized(String resMsg) {
-        return JsonResult.builder()
-                .resCode(HttpStatus.UNAUTHORIZED.value())
                 .resMsg(resMsg)
                 .build();
     }
@@ -74,7 +45,6 @@ public class JsonResult<T> {
     @Override
     public String toString() {
         return "JsonResult{" +
-                "resCode=" + resCode +
                 ", resObj=" + resObj +
                 ", resMsg='" + resMsg + '\'' +
                 '}';

--- a/backend/src/test/java/com/example/backend/auth/api/controller/auth/AuthControllerTest.java
+++ b/backend/src/test/java/com/example/backend/auth/api/controller/auth/AuthControllerTest.java
@@ -77,8 +77,7 @@ class AuthControllerTest extends MockTestConfig {
 
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(401))
+                .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.res_msg").value(ExceptionMessage.JWT_MALFORMED.getText()));
     }
 
@@ -96,15 +95,15 @@ class AuthControllerTest extends MockTestConfig {
         String accessToken = jwtService.generateAccessToken(map, savedUser);
         String refreshToken = jwtService.generateRefreshToken(map, savedUser);
 
-
         // when
         mockMvc.perform(post("/auth/logout")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
+
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
-                .andExpect(jsonPath("$.res_obj").value("로그아웃 되었습니다."));
+                .andExpect(jsonPath("$.res_obj").value("로그아웃 되었습니다."))
+                .andDo(print());
     }
 
     @Test
@@ -113,8 +112,8 @@ class AuthControllerTest extends MockTestConfig {
         mockMvc.perform(post("/auth/logout")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, "INVALID HEADER"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+
+                .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.res_msg").value(ExceptionMessage.JWT_INVALID_HEADER.getText()));
     }
 
@@ -142,8 +141,8 @@ class AuthControllerTest extends MockTestConfig {
                 .andDo(result -> {
                     System.out.println(result.getResponse().getContentAsString());
                 })
+
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"));
     }
 
@@ -170,7 +169,7 @@ class AuthControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200));
+                .andExpect(jsonPath("$.res_msg").value("OK"));
 
     }
 
@@ -195,9 +194,9 @@ class AuthControllerTest extends MockTestConfig {
         mockMvc.perform(get("/auth/info")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
+
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_obj.role").value(String.valueOf(UserRole.USER)))
                 .andExpect(jsonPath("$.res_obj.name").value(savedUser.getName()))
                 .andExpect(jsonPath("$.res_obj.profile_image_url").value(savedUser.getProfileImageUrl()));
@@ -215,9 +214,9 @@ class AuthControllerTest extends MockTestConfig {
         mockMvc.perform(get("/auth/info")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
+
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(401))
+                .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.res_msg").value(ExceptionMessage.JWT_MALFORMED.getText()));
     }
 
@@ -239,9 +238,9 @@ class AuthControllerTest extends MockTestConfig {
         mockMvc.perform(get("/auth/info")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
+
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(ExceptionMessage.UNAUTHORIZED_AUTHORITY.getText()))
                 .andDo(print());
 
@@ -269,7 +268,6 @@ class AuthControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_obj.name").value(savedUser.getName()))
                 .andExpect(jsonPath("$.res_obj.profile_image_url").value(savedUser.getProfileImageUrl()))
                 .andDo(print());
@@ -293,8 +291,7 @@ class AuthControllerTest extends MockTestConfig {
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(ExceptionMessage.UNAUTHORIZED_AUTHORITY.getText()))
                 .andDo(print());
 
@@ -329,7 +326,6 @@ class AuthControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("User Update Success."))
                 .andDo(print());
@@ -365,8 +361,7 @@ class AuthControllerTest extends MockTestConfig {
                         .content(objectMapper.writeValueAsString(updateRequest)))
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(ExceptionMessage.UNAUTHORIZED_AUTHORITY.getText()))
                 .andDo(print());
     }
@@ -400,8 +395,7 @@ class AuthControllerTest extends MockTestConfig {
                         .content(objectMapper.writeValueAsString(updateRequest)))
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(expectedError))
                 .andDo(print());
     }
@@ -426,7 +420,6 @@ class AuthControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("PushAlarmYn Update Success."))
                 .andDo(print());
@@ -449,8 +442,7 @@ class AuthControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(ExceptionMessage.UNAUTHORIZED_AUTHORITY.getText()))
                 .andDo(print());
     }
@@ -469,7 +461,6 @@ class AuthControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("Nickname Duplication Check Success."))
                 .andDo(print());
@@ -491,8 +482,7 @@ class AuthControllerTest extends MockTestConfig {
                         .content(objectMapper.writeValueAsString(request)))
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(expectedError))
                 .andDo(print());
     }
@@ -513,8 +503,7 @@ class AuthControllerTest extends MockTestConfig {
                         .content(objectMapper.writeValueAsString(request)))
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(expectedError))
                 .andDo(print());
     }

--- a/backend/src/test/java/com/example/backend/common/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/example/backend/common/exception/GlobalExceptionHandlerTest.java
@@ -1,8 +1,6 @@
 package com.example.backend.common.exception;
 
 import com.example.backend.common.exception.jwt.JwtException;
-import com.example.backend.common.response.JsonResult;
-import com.google.api.Http;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -11,8 +9,8 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class GlobalExceptionHandlerTest {
     // @SpringBootTest 사용 안하고 테스트하기 위해 그냥 생성
@@ -28,11 +26,11 @@ class GlobalExceptionHandlerTest {
         String expectedResponseMessage = "fieldName: error message";
 
         // when
-        JsonResult result = globalExceptionHandler.bindException(bindException);
+        var result = globalExceptionHandler.bindException(bindException);
 
         // then
-        assertThat(result.getResCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-        assertThat(result.getResMsg()).isEqualTo(expectedResponseMessage);
+        assertEquals(result.getStatusCode().value(), HttpStatus.BAD_REQUEST.value());
+        assertThat(result.getBody().getResMsg()).isEqualTo(expectedResponseMessage);
 
     }
 
@@ -47,11 +45,11 @@ class GlobalExceptionHandlerTest {
         String expectedResponseMessage = "fieldName: error message";
 
         // when
-        JsonResult result = globalExceptionHandler.handleMethodArgumentNotValid(error);
+        var result = globalExceptionHandler.handleMethodArgumentNotValid(error);
 
         // then
-        assertThat(result.getResCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-        assertThat(result.getResMsg()).isEqualTo(expectedResponseMessage);
+        assertEquals(result.getStatusCode().value(), HttpStatus.BAD_REQUEST.value());
+        assertThat(result.getBody().getResMsg()).isEqualTo(expectedResponseMessage);
 
     }
 
@@ -62,11 +60,11 @@ class GlobalExceptionHandlerTest {
         JwtException exception = new JwtException(ExceptionMessage.JWT_MALFORMED);
 
         // when
-        JsonResult result = globalExceptionHandler.handleJwtException(exception);
+        var result = globalExceptionHandler.handleJwtException(exception);
 
         // then
-        assertThat(result.getResCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
-        assertThat(result.getResMsg()).isEqualTo(ExceptionMessage.JWT_MALFORMED.getText());
+        assertEquals(result.getStatusCode().value(), HttpStatus.UNAUTHORIZED.value());
+        assertThat(result.getBody().getResMsg()).isEqualTo(ExceptionMessage.JWT_MALFORMED.getText());
     }
 
     @Test
@@ -76,10 +74,10 @@ class GlobalExceptionHandlerTest {
         Exception exception = new Exception(ExceptionMessage.AUTH_NOT_FOUND.getText());
 
         // when
-        JsonResult result = globalExceptionHandler.exception(exception);
+        var result = globalExceptionHandler.exception(exception);
 
         // then
-        assertThat(result.getResCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-        assertThat(result.getResMsg()).isEqualTo(ExceptionMessage.AUTH_NOT_FOUND.getText());
+        assertEquals(result.getStatusCode().value(), HttpStatus.BAD_REQUEST.value());
+        assertThat(result.getBody().getResMsg()).isEqualTo(ExceptionMessage.AUTH_NOT_FOUND.getText());
     }
 }

--- a/backend/src/test/java/com/example/backend/study/api/controller/bookmark/StudyBookmarkControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/controller/bookmark/StudyBookmarkControllerTest.java
@@ -65,7 +65,6 @@ class StudyBookmarkControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").isNotEmpty())
                 .andDo(print());
@@ -94,7 +93,6 @@ class StudyBookmarkControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").isNotEmpty())
                 .andDo(print());
@@ -120,8 +118,7 @@ class StudyBookmarkControllerTest extends MockTestConfig {
                         .param("limit", "5"))
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(ExceptionMessage.UNAUTHORIZED_AUTHORITY.getText()))
                 .andDo(print());
     }
@@ -143,8 +140,7 @@ class StudyBookmarkControllerTest extends MockTestConfig {
                         .param("limit", "-1"))
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value("400 BAD_REQUEST \"Validation failure\""))
                 .andDo(print());
     }
@@ -170,7 +166,6 @@ class StudyBookmarkControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("북마크 등록/삭제에 성공하였습니다."))
                 .andDo(print());
@@ -195,8 +190,7 @@ class StudyBookmarkControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value("계정 정보를 찾을 수 없습니다."))
                 .andDo(print());
     }

--- a/backend/src/test/java/com/example/backend/study/api/controller/category/info/CategoryControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/controller/category/info/CategoryControllerTest.java
@@ -93,7 +93,6 @@ class CategoryControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("Category Register Success."))
                 .andDo(print());
@@ -123,8 +122,7 @@ class CategoryControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(request)))
 
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(expectedError))
                 .andDo(print());
     }
@@ -154,8 +152,7 @@ class CategoryControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(request)))
 
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(expectedError))
                 .andDo(print());
     }
@@ -184,7 +181,6 @@ class CategoryControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("Category update Success"))
                 .andDo(print());
@@ -217,8 +213,7 @@ class CategoryControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(request)))
 
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(expectedError))
                 .andDo(print());
     }
@@ -250,8 +245,7 @@ class CategoryControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(request)))
 
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(expectedError))
                 .andDo(print());
     }
@@ -280,8 +274,7 @@ class CategoryControllerTest extends MockTestConfig {
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(ExceptionMessage.CATEGORY_NOT_FOUND.getText()))
                 .andDo(print());
     }
@@ -306,7 +299,6 @@ class CategoryControllerTest extends MockTestConfig {
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("Category deleted successfully"))
                 .andDo(print());
@@ -333,8 +325,7 @@ class CategoryControllerTest extends MockTestConfig {
         mockMvc.perform(delete("/category/" + studyCategory.getId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(ExceptionMessage.UNAUTHORIZED_AUTHORITY.getText()))
                 .andDo(print());
     }
@@ -364,7 +355,6 @@ class CategoryControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").isNotEmpty())
                 .andDo(print());
@@ -395,8 +385,7 @@ class CategoryControllerTest extends MockTestConfig {
                         .param("limit", "5"))
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(ExceptionMessage.UNAUTHORIZED_AUTHORITY.getText()))
                 .andDo(print());
     }
@@ -421,8 +410,7 @@ class CategoryControllerTest extends MockTestConfig {
                         .param("limit", "-1"))
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value("400 BAD_REQUEST \"Validation failure\""))
                 .andDo(print());
     }

--- a/backend/src/test/java/com/example/backend/study/api/controller/comment/commit/CommitCommentControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/controller/comment/commit/CommitCommentControllerTest.java
@@ -71,7 +71,6 @@ class CommitCommentControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").isNotEmpty())
                 .andDo(print());
@@ -97,8 +96,7 @@ class CommitCommentControllerTest extends MockTestConfig {
                         .param("studyInfoId", "1"))
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(ExceptionMessage.AUTH_NOT_FOUND.getText()))
                 .andDo(print());
 
@@ -126,7 +124,6 @@ class CommitCommentControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andDo(print());
 
@@ -152,8 +149,7 @@ class CommitCommentControllerTest extends MockTestConfig {
                         .content(objectMapper.writeValueAsString(AddCommitCommentRequest.builder().content(inValidContent).build())))
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(expectedError))
                 .andDo(print());
     }
@@ -177,8 +173,7 @@ class CommitCommentControllerTest extends MockTestConfig {
                         .content(objectMapper.writeValueAsString(AddCommitCommentRequest.builder().content("test").build())))
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(ExceptionMessage.STUDY_NOT_MEMBER.getText()))
                 .andDo(print());
 

--- a/backend/src/test/java/com/example/backend/study/api/controller/comment/study/StudyCommentControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/controller/comment/study/StudyCommentControllerTest.java
@@ -99,7 +99,6 @@ class StudyCommentControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(studyCommentRegisterRequest)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("StudyComment register Success"))
                 .andDo(print());
@@ -128,7 +127,6 @@ class StudyCommentControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(studyCommentUpdateRequest)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("StudyComment update Success"))
                 .andDo(print());
@@ -155,7 +153,6 @@ class StudyCommentControllerTest extends MockTestConfig {
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("StudyComment deleted successfully"))
                 .andDo(print());
@@ -186,7 +183,6 @@ class StudyCommentControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").isNotEmpty())
                 .andDo(print());
@@ -217,7 +213,6 @@ class StudyCommentControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").isEmpty())
                 .andDo(print());
@@ -246,8 +241,7 @@ class StudyCommentControllerTest extends MockTestConfig {
                         .param("limit", "5"))
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(ExceptionMessage.UNAUTHORIZED_AUTHORITY.getText()))
                 .andDo(print());
     }
@@ -270,8 +264,7 @@ class StudyCommentControllerTest extends MockTestConfig {
                         .param("limit", "-1"))
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value("400 BAD_REQUEST \"Validation failure\""))
                 .andDo(print());
     }

--- a/backend/src/test/java/com/example/backend/study/api/controller/commit/StudyCommitControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/controller/commit/StudyCommitControllerTest.java
@@ -76,7 +76,6 @@ class StudyCommitControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").isNotEmpty())
                 .andDo(print());
@@ -104,7 +103,6 @@ class StudyCommitControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").isNotEmpty())
                 .andDo(print());
@@ -131,8 +129,7 @@ class StudyCommitControllerTest extends MockTestConfig {
                         .param("limit", "20"))
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(ExceptionMessage.UNAUTHORIZED_AUTHORITY.getText()))
                 .andDo(print());
 
@@ -158,8 +155,7 @@ class StudyCommitControllerTest extends MockTestConfig {
                         .param("limit", "0"))
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value("400 BAD_REQUEST \"Validation failure\""))
                 .andDo(print());
     }
@@ -187,7 +183,6 @@ class StudyCommitControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj.commit_sha").value(commitSha))
                 .andDo(print());
@@ -214,8 +209,7 @@ class StudyCommitControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(ExceptionMessage.COMMIT_NOT_FOUND.getText()))
                 .andDo(print());
     }
@@ -242,7 +236,6 @@ class StudyCommitControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("커밋 승인이 완료되었습니다."))
                 .andDo(print());
@@ -275,7 +268,6 @@ class StudyCommitControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("커밋 거절이 완료되었습니다."))
                 .andDo(print());
@@ -305,8 +297,7 @@ class StudyCommitControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(errorMsg))
                 .andDo(print());
     }
@@ -332,7 +323,6 @@ class StudyCommitControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj[0].commit_sha").value(commitSha))
                 .andDo(print());
@@ -357,8 +347,7 @@ class StudyCommitControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
 
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(ExceptionMessage.STUDY_MEMBER_NOT_LEADER.getText()))
                 .andDo(print());
     }

--- a/backend/src/test/java/com/example/backend/study/api/controller/convention/StudyConventionControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/controller/convention/StudyConventionControllerTest.java
@@ -97,7 +97,6 @@ public class StudyConventionControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("StudyConvention register Success"))
                 .andDo(print());
@@ -127,8 +126,7 @@ public class StudyConventionControllerTest extends MockTestConfig {
                                 .content("정규식")
                                 .build())))
 
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(expectedError))
                 .andDo(print());
     }
@@ -161,7 +159,6 @@ public class StudyConventionControllerTest extends MockTestConfig {
                         .content(objectMapper.writeValueAsString(updateRequest)))
 
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("StudyConvention update Success"))
                 .andDo(print());
@@ -201,8 +198,7 @@ public class StudyConventionControllerTest extends MockTestConfig {
                                 .content(inValidContent)
                                 .build())))
 
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value(expectedError))
                 .andDo(print());
     }
@@ -232,7 +228,6 @@ public class StudyConventionControllerTest extends MockTestConfig {
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("StudyConvention delete Success"))
                 .andDo(print());
@@ -263,7 +258,6 @@ public class StudyConventionControllerTest extends MockTestConfig {
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj.name").value(response.getName()))
                 .andExpect(jsonPath("$.res_obj").isNotEmpty())
@@ -301,7 +295,6 @@ public class StudyConventionControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
 
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").isNotEmpty())
                 .andDo(print());
@@ -338,7 +331,6 @@ public class StudyConventionControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
 
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").isEmpty())
                 .andDo(print());

--- a/backend/src/test/java/com/example/backend/study/api/controller/info/StudyInfoControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/controller/info/StudyInfoControllerTest.java
@@ -102,7 +102,6 @@ class StudyInfoControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("Study Register Success."))
                 .andDo(print());
@@ -131,8 +130,7 @@ class StudyInfoControllerTest extends MockTestConfig {
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value("maximumMember: must be less than or equal to 10"))
                 .andDo(print());
     }
@@ -160,8 +158,7 @@ class StudyInfoControllerTest extends MockTestConfig {
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value("maximumMember: must be greater than or equal to 1"))
                 .andDo(print());
     }
@@ -188,7 +185,6 @@ class StudyInfoControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                 )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"));
     }
 
@@ -221,7 +217,6 @@ class StudyInfoControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(studyInfoUpdateRequest)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("StudyInfo update Success"))
                 .andDo(print());
@@ -253,7 +248,6 @@ class StudyInfoControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                 )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andDo(print());
 
@@ -284,7 +278,6 @@ class StudyInfoControllerTest extends MockTestConfig {
                 )
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andDo(print());
     }
@@ -314,7 +307,6 @@ class StudyInfoControllerTest extends MockTestConfig {
                 )
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andDo(print());
     }
@@ -341,8 +333,7 @@ class StudyInfoControllerTest extends MockTestConfig {
                         .param("myStudy", "true")
                 )
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value("400 BAD_REQUEST \"Validation failure\""))
                 .andDo(print());
     }
@@ -370,7 +361,6 @@ class StudyInfoControllerTest extends MockTestConfig {
                 )
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andDo(print());
     }
@@ -397,11 +387,11 @@ class StudyInfoControllerTest extends MockTestConfig {
                         .param("myStudy", "false")
                 )
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(400))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.res_msg").value("400 BAD_REQUEST \"Validation failure\""))
                 .andDo(print());
     }
+
     @Test
     void 스터디_상세정보_조회_성공_테스트() throws Exception {
         // given
@@ -426,7 +416,6 @@ class StudyInfoControllerTest extends MockTestConfig {
                 )
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andDo(print());
     }
@@ -453,7 +442,6 @@ class StudyInfoControllerTest extends MockTestConfig {
                 )
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andDo(print());
     }
@@ -481,7 +469,6 @@ class StudyInfoControllerTest extends MockTestConfig {
                 )
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andDo(print());
     }

--- a/backend/src/test/java/com/example/backend/study/api/controller/member/StudyMemberControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/controller/member/StudyMemberControllerTest.java
@@ -93,8 +93,7 @@ public class StudyMemberControllerTest extends MockTestConfig {
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
                 // then
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200));
+                .andExpect(status().isOk());
 
     }
 
@@ -126,7 +125,6 @@ public class StudyMemberControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_obj").value("Resign Member Success"));
     }
 
@@ -158,7 +156,6 @@ public class StudyMemberControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_obj").value("Withdrawal Member Success"));
     }
 
@@ -187,7 +184,6 @@ public class StudyMemberControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_obj").value("Apply StudyMember Success"));
 
     }
@@ -214,7 +210,6 @@ public class StudyMemberControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_obj").value("Apply Approve or Refuse StudyMember Success"));
 
     }
@@ -241,7 +236,6 @@ public class StudyMemberControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_obj").value("Apply cancel StudyMember Success"));
 
     }
@@ -275,7 +269,6 @@ public class StudyMemberControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").isNotEmpty())
                 .andDo(print());
@@ -309,7 +302,6 @@ public class StudyMemberControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").isEmpty())
                 .andDo(print());
@@ -339,7 +331,6 @@ public class StudyMemberControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_obj").value("Notify to StudyMember Success"));
 
     }
@@ -369,7 +360,6 @@ public class StudyMemberControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_obj").value("Notify to StudyLeader Success"));
 
     }

--- a/backend/src/test/java/com/example/backend/study/api/controller/todo/StudyTodoControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/controller/todo/StudyTodoControllerTest.java
@@ -119,7 +119,6 @@ public class StudyTodoControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(studyTodoRequest)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("Todo register Success"))
                 .andDo(print());
@@ -160,7 +159,6 @@ public class StudyTodoControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(updateRequest)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("Todo update Success"))
                 .andDo(print());
@@ -193,7 +191,6 @@ public class StudyTodoControllerTest extends MockTestConfig {
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("Todo delete Success"))
                 .andDo(print());
@@ -228,7 +225,6 @@ public class StudyTodoControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").isNotEmpty())
                 .andDo(print());
@@ -263,7 +259,6 @@ public class StudyTodoControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").isEmpty())
                 .andDo(print());
@@ -295,7 +290,6 @@ public class StudyTodoControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj.title").value(response.getTitle()))
                 .andDo(print());
@@ -335,7 +329,6 @@ public class StudyTodoControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").isNotEmpty())
                 .andDo(print());
@@ -367,7 +360,6 @@ public class StudyTodoControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").isNotEmpty())
                 .andDo(print());
@@ -393,7 +385,6 @@ public class StudyTodoControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("커밋 패치가 완료되었습니다."))
                 .andDo(print());
@@ -422,7 +413,6 @@ public class StudyTodoControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj[0].commit_sha").value("tt"))
                 .andDo(print());

--- a/backend/src/test/java/com/example/backend/study/api/event/controller/FcmControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/event/controller/FcmControllerTest.java
@@ -74,7 +74,6 @@ class FcmControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(token)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("FCM token save Success."))
                 .andDo(print());
@@ -99,7 +98,6 @@ class FcmControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(fcmSingleTokenRequest)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("Fcm Single Success"))
                 .andDo(print());
@@ -124,7 +122,6 @@ class FcmControllerTest extends MockTestConfig {
                         .header(AUTHORIZATION, createAuthorizationHeader(accessToken, refreshToken))
                         .content(objectMapper.writeValueAsString(fcmMultiTokenRequest)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("Fcm Multi Success"))
                 .andDo(print());

--- a/backend/src/test/java/com/example/backend/study/api/event/controller/NoticeControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/event/controller/NoticeControllerTest.java
@@ -78,7 +78,6 @@ class NoticeControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andDo(print());
     }
@@ -101,7 +100,6 @@ class NoticeControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("Notice delete Success"))
                 .andDo(print());
@@ -124,7 +122,6 @@ class NoticeControllerTest extends MockTestConfig {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.res_code").value(200))
                 .andExpect(jsonPath("$.res_msg").value("OK"))
                 .andExpect(jsonPath("$.res_obj").value("All Notice delete Success"))
                 .andDo(print());


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#403 

### Pull Request Type
- [ ]  새로운 기능 추가
- [x]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [x]  테스트 추가, 테스트 리팩토링
- [ ]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist
- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용

현재 모든 응답(실패와 성공 관계없이) 전부 HttpStatus가 OK이고, 그 안의 Body인 커스텀 응답 객체 JsonResult의 res_code와 res_msg를 통해 성공, 실패를 판단하고 있어서 프론트 단에서 토큰 관련 재발급 처리가 어려운 상황

성공 시에는 기존의 커스텀 객체를 사용하도록 두고, 실패를 했을 경우 ResponseEntity를 사용해 HttpStatus를 변경해준다.

토큰 관련 인증 실패(JwtException) -> HttpStatus.UNAUTHORIZED
그 외의 실패 -> HttpStatus.BAD_REQUEST


## 💬 리뷰 요구사항

ResponseEntity의 HttpStatus를 적용하면서 JsonResult의 res_code는 의미가 중복되어 삭제하였습니다!

