### PR TITLE
[BE] feat(#410) GitHub access token 저장 로직 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/auth/api/service/auth/AuthService.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/auth/AuthService.java
@@ -22,6 +22,8 @@ import com.example.backend.domain.define.account.user.constant.UserRole;
 import com.example.backend.domain.define.account.user.repository.UserRepository;
 import com.example.backend.domain.define.refreshToken.RefreshToken;
 import com.example.backend.domain.define.refreshToken.repository.RefreshTokenRepository;
+import com.example.backend.domain.define.study.github.GithubApiToken;
+import com.example.backend.domain.define.study.github.repository.GithubApiTokenRepository;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,6 +46,7 @@ public class AuthService {
     private final JwtService jwtService;
     private final RefreshTokenService refreshTokenService;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final GithubApiTokenRepository githubApiTokenRepository;
 
     @Transactional
     public AuthLoginResponse login(UserPlatformType platformType, String code, String state) {
@@ -70,7 +73,14 @@ public class AuthService {
                             .build();
 
                     log.info(">>>> [ UNAUTH 권한으로 사용자를 DB에 등록합니다. 이후 회원가입이 필요합니다 ] <<<<");
-                    return userRepository.save(saveUser);
+
+                    User user = userRepository.save(saveUser);
+                    githubApiTokenRepository.save(GithubApiToken.builder()
+                            .userId(user.getId())
+                            .githubApiToken(loginResponse.getGithubApiToken())
+                            .build());
+
+                    return user;
                 });
 
         /*

--- a/backend/src/main/java/com/example/backend/auth/api/service/oauth/adapter/github/GithubAdapter.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/oauth/adapter/github/GithubAdapter.java
@@ -50,6 +50,7 @@ public class GithubAdapter implements OAuthAdapter {
                     .platformType(GITHUB)
                     .name(profile.getLogin())
                     .profileImageUrl(profile.getAvatar_url())
+                    .githubApiToken(accessToken)
                     .build();
         } catch (RuntimeException e) {
             log.error(">>>> [ Github Oauth 인증 에러 발생: {} ] <<<<", ExceptionMessage.OAUTH_INVALID_ACCESS_TOKEN.getText());

--- a/backend/src/main/java/com/example/backend/auth/api/service/oauth/builder/github/GithubURLBuilder.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/oauth/builder/github/GithubURLBuilder.java
@@ -46,7 +46,7 @@ public class GithubURLBuilder implements OAuthURLBuilder {
                 + "&client_id=" + clientId          // 클라이언트 ID
                 + "&redirect_uri=" + redirectUri    // 리다이렉트 URI
                 + "&state=" + state                 // CSRF 방지
-                + "&scope=openid";                  // 리소스 접근 범위: openid로 고정
+                + "&scope=openid,repo";                  // 리소스 접근 범위: openid로 고정
     }
 
     // "https://github.com/login/oauth/access_token?..."

--- a/backend/src/main/java/com/example/backend/auth/api/service/oauth/response/OAuthResponse.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/oauth/response/OAuthResponse.java
@@ -12,12 +12,13 @@ public class OAuthResponse {
     private UserPlatformType platformType;
     private String name;
     private String profileImageUrl;
-
+    private String githubApiToken;
     @Builder
-    public OAuthResponse(String platformId, UserPlatformType platformType, String name, String profileImageUrl) {
+    public OAuthResponse(String platformId, UserPlatformType platformType, String name, String profileImageUrl, String githubApiToken) {
         this.platformId = platformId;
         this.platformType = platformType;
         this.name = name;
         this.profileImageUrl = profileImageUrl;
+        this.githubApiToken = githubApiToken;
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/define/study/github/GithubApiToken.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/github/GithubApiToken.java
@@ -1,0 +1,24 @@
+package com.example.backend.domain.define.study.github;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@ToString
+@RedisHash(value = "github")
+@NoArgsConstructor
+@Builder
+public class GithubApiToken {
+    @Id
+    private Long userId;
+    private String githubApiToken;
+
+    public GithubApiToken(Long userId, String githubApiToken) {
+        this.userId = userId;
+        this.githubApiToken = githubApiToken;
+    }
+}

--- a/backend/src/main/java/com/example/backend/domain/define/study/github/repository/GithubApiTokenRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/github/repository/GithubApiTokenRepository.java
@@ -1,0 +1,7 @@
+package com.example.backend.domain.define.study.github.repository;
+
+import com.example.backend.domain.define.study.github.GithubApiToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface GithubApiTokenRepository extends CrudRepository<GithubApiToken, Long> {
+}

--- a/backend/src/test/java/com/example/backend/auth/api/service/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/example/backend/auth/api/service/auth/AuthServiceTest.java
@@ -22,6 +22,8 @@ import com.example.backend.domain.define.account.user.constant.UserRole;
 import com.example.backend.domain.define.account.user.repository.UserRepository;
 import com.example.backend.domain.define.refreshToken.RefreshToken;
 import com.example.backend.domain.define.refreshToken.repository.RefreshTokenRepository;
+import com.example.backend.domain.define.study.github.GithubApiToken;
+import com.example.backend.domain.define.study.github.repository.GithubApiTokenRepository;
 import io.jsonwebtoken.Claims;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -64,6 +66,9 @@ class AuthServiceTest extends MockTestConfig {
     @Autowired
     private RefreshTokenRepository refreshTokenRepository;
 
+    @Autowired
+    private GithubApiTokenRepository githubApiTokenRepository;
+
     @AfterEach
     void tearDown() {
         userRepository.deleteAllInBatch();
@@ -75,6 +80,7 @@ class AuthServiceTest extends MockTestConfig {
         // given
         String code = "code";
         String state = "state";
+        String token = "githubApiToken";
 
         OAuthResponse oAuthResponse = generateOauthResponse();
         UserPlatformType platformType = oAuthResponse.getPlatformType();
@@ -87,10 +93,14 @@ class AuthServiceTest extends MockTestConfig {
         authService.login(GITHUB, code, state);
 
         User user = userRepository.findByPlatformIdAndPlatformType(platformId, platformType).get();
+        GithubApiToken githubApiToken = githubApiTokenRepository.findById(user.getId()).get();
 
         // then
         assertThat(user).isNotNull();
         assertThat(user.getRole().name()).isEqualTo(UserRole.UNAUTH.name());
+
+        // githubApiToken 생성 검증
+        assertThat(githubApiToken.getGithubApiToken()).isEqualTo(token);
     }
 
     @Test

--- a/backend/src/test/java/com/example/backend/auth/api/service/oauth/builder/github/GithubURLBuilderTest.java
+++ b/backend/src/test/java/com/example/backend/auth/api/service/oauth/builder/github/GithubURLBuilderTest.java
@@ -36,7 +36,7 @@ class GithubURLBuilderTest extends TestConfig {
                 + "&client_id=" + clientId
                 + "&redirect_uri=" + redirectUri
                 + "&state=" + state
-                + "&scope=openid");
+                + "&scope=openid,repo");
     }
 
     @Test

--- a/backend/src/test/java/com/example/backend/auth/config/fixture/UserFixture.java
+++ b/backend/src/test/java/com/example/backend/auth/config/fixture/UserFixture.java
@@ -81,6 +81,7 @@ public class UserFixture {
                 .platformType(GITHUB)
                 .name("이름")
                 .profileImageUrl("프로필이미지")
+                .githubApiToken("githubApiToken")
                 .build();
     }
 

--- a/backend/src/test/java/com/example/backend/domain/define/study/github/repository/GithubApiTokenRepositoryTest.java
+++ b/backend/src/test/java/com/example/backend/domain/define/study/github/repository/GithubApiTokenRepositoryTest.java
@@ -1,0 +1,45 @@
+package com.example.backend.domain.define.study.github.repository;
+
+import com.example.backend.TestConfig;
+import com.example.backend.auth.config.fixture.UserFixture;
+import com.example.backend.domain.define.account.user.User;
+import com.example.backend.domain.define.account.user.repository.UserRepository;
+import com.example.backend.domain.define.study.github.GithubApiToken;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GithubApiTokenRepositoryTest extends TestConfig {
+    @Autowired
+    private GithubApiTokenRepository githubApiTokenRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @AfterEach
+    void tearDown() {
+        githubApiTokenRepository.deleteAll();
+        userRepository.deleteAllInBatch();
+    }
+    @Test
+    @DisplayName("github api token을 저장할 수 있다.")
+    void saveGithubApiToken() {
+        // given
+        User user = userRepository.save(UserFixture.generateAuthUser());
+        GithubApiToken githubApiToken = githubApiTokenRepository.save(GithubApiToken.builder()
+                .userId(user.getId())
+                .githubApiToken("token")
+                .build());
+
+        // when
+        GithubApiToken savedGithubApiToken = githubApiTokenRepository.findById(githubApiToken.getUserId()).get();
+
+        // then
+        assertThat(githubApiToken.getUserId()).isEqualTo(savedGithubApiToken.getUserId());
+        assertThat(githubApiToken.getGithubApiToken()).isEqualTo(savedGithubApiToken.getGithubApiToken());
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

ex) #410 

### Pull Request Type

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [x]  테스트 추가, 테스트 리팩토링
- [ ]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용

로그인시 github access_token을 redis에 저장한다.(github access_token은 자주 사용되므로 redis 사용해서 캐싱)

- repo 권한 설정 
- GithubApiToken 추가 {key : userId, value : github access_token}
- 레디스 저장, 조회 로직 및 테스트 추가
- 로그인 시 토큰 저장 로직 및 테스트 추가

### 레디스 테스트
![화면 캡처 2024-07-13 153725](https://github.com/user-attachments/assets/cafc6444-4679-4034-ad52-61b7c7e9f333)


## 💬 리뷰 요구사항

놓친 점이나 리팩토링 필요한 부분 지적해주세요!

reissue는 추후에 구현 예정입니다.
