### PR TITLE
[BE] feat(#431): 웹 훅 데이터를 활용한 커밋 처리 로직 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/auth/config/security/SecurityConfig.java
+++ b/backend/src/main/java/com/example/backend/auth/config/security/SecurityConfig.java
@@ -25,14 +25,14 @@ public class SecurityConfig {
                         authorizeHttpRequest
                                 // Swagger 추가
                                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/auth/v3/**", "/auth/swagger-ui/**").permitAll()
+                                // Webhook Area
+                                .requestMatchers("/webhook/**").hasAnyAuthority("ADMIN")
                                 // register
                                 .requestMatchers("/auth/register").hasAnyAuthority("UNAUTH")
                                 // UnAuth Area
                                 .requestMatchers("/auth/loginPage").permitAll()
                                 .requestMatchers("/auth/*/login").permitAll()
                                 .requestMatchers("/auth/check-nickname").permitAll()
-                                // Webhook Area
-                                .requestMatchers("/webhook/**").permitAll()
                                 // Others
                                 .anyRequest().hasAnyAuthority("USER", "ADMIN")
                 )

--- a/backend/src/main/java/com/example/backend/auth/config/security/SecurityConfig.java
+++ b/backend/src/main/java/com/example/backend/auth/config/security/SecurityConfig.java
@@ -31,6 +31,8 @@ public class SecurityConfig {
                                 .requestMatchers("/auth/loginPage").permitAll()
                                 .requestMatchers("/auth/*/login").permitAll()
                                 .requestMatchers("/auth/check-nickname").permitAll()
+                                // Webhook Area
+                                .requestMatchers("/webhook/**").permitAll()
                                 // Others
                                 .anyRequest().hasAnyAuthority("USER", "ADMIN")
                 )

--- a/backend/src/main/java/com/example/backend/common/exception/ExceptionMessage.java
+++ b/backend/src/main/java/com/example/backend/common/exception/ExceptionMessage.java
@@ -67,6 +67,7 @@ public enum ExceptionMessage {
     STUDY_WAITING_NOT_MEMBER("해당 스터디에 가입 대기중인 유저가 아닙니다."),
     STUDY_JOIN_CODE_FAIL("스터디 참여 코드가 맞지 않습니다."),
     STUDY_NOT_APPLY_LIST("해당 스터디에 가입신청이 없습니다"),
+    STUDY_NOT_ACTIVE_MEMBER("해당 스터디의 활동중인 스터디원이 아닙니다."),
 
     // StudyCommentException
     STUDY_COMMENT_NOT_FOUND("해당 스터디 댓글을 찾을 수 없습니다."),
@@ -74,6 +75,7 @@ public enum ExceptionMessage {
 
     // StudyConventionException
     CONVENTION_NOT_FOUND("해당 스터디 컨벤션을 찾을 수 없습니다."),
+    CONVENTION_NOT_MATCHED("컨벤션을 만족하지 않습니다."),
 
     // GithubApiException
     GITHUB_API_CONNECTION_ERROR("Github Api 통신에 실패했습니다."),

--- a/backend/src/main/java/com/example/backend/common/exception/webhook/WebhookException.java
+++ b/backend/src/main/java/com/example/backend/common/exception/webhook/WebhookException.java
@@ -1,0 +1,10 @@
+package com.example.backend.common.exception.webhook;
+
+import com.example.backend.common.exception.ExceptionMessage;
+import com.example.backend.common.exception.GitudyException;
+
+public class WebhookException extends GitudyException {
+    public WebhookException(ExceptionMessage message) {
+        super(message.getText());
+    }
+}

--- a/backend/src/main/java/com/example/backend/domain/define/study/commit/repository/StudyCommitRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/commit/repository/StudyCommitRepository.java
@@ -5,6 +5,7 @@ import com.example.backend.domain.define.study.commit.constant.CommitStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface StudyCommitRepository extends JpaRepository<StudyCommit, Long>, StudyCommitRepositoryCustom {
     List<StudyCommit> findByStudyTodoId(long todoId);
@@ -14,4 +15,6 @@ public interface StudyCommitRepository extends JpaRepository<StudyCommit, Long>,
     List<StudyCommit> findStudyCommitListByStudyInfoIdAndStatus(Long studyInfoId, CommitStatus status);
 
     boolean existsByCommitSHA(String commitSha);
+
+    Optional<StudyCommit> findByStudyTodoIdAndUserId(Long todoId, Long userId);
 }

--- a/backend/src/main/java/com/example/backend/domain/define/study/info/repository/StudyInfoRepositoryCustom.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/info/repository/StudyInfoRepositoryCustom.java
@@ -1,8 +1,10 @@
 package com.example.backend.domain.define.study.info.repository;
 
+import com.example.backend.domain.define.study.info.StudyInfo;
 import com.example.backend.study.api.controller.info.response.StudyInfoListResponse;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface StudyInfoRepositoryCustom {
 
@@ -11,4 +13,7 @@ public interface StudyInfoRepositoryCustom {
 
     // 마이/전체 스터디 개수 조회
     int findStudyInfoCount(Long userId, boolean myStudy);
+
+    // 레포지토리 정보를 통해 스터디 조회
+    Optional<StudyInfo> findByRepositoryFullName(String owner, String repositoryName);
 }

--- a/backend/src/main/java/com/example/backend/domain/define/study/info/repository/StudyInfoRepositoryImpl.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/info/repository/StudyInfoRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.example.backend.domain.define.study.info.repository;
 
+import com.example.backend.domain.define.study.info.StudyInfo;
 import com.example.backend.domain.define.study.info.constant.StudyStatus;
 import com.example.backend.study.api.controller.info.response.StudyInfoListResponse;
 import com.querydsl.core.types.OrderSpecifier;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.example.backend.domain.define.study.info.QStudyInfo.studyInfo;
 import static com.example.backend.domain.define.study.info.constant.StudyStatus.STUDY_PRIVATE;
@@ -122,6 +124,14 @@ public class StudyInfoRepositoryImpl implements StudyInfoRepositoryCustom {
         }
 
         return query.fetchOne().intValue(); // 결과를 int로 변환하여 리턴
+    }
+
+    @Override
+    public Optional<StudyInfo> findByRepositoryFullName(String owner, String repositoryName) {
+        return Optional.ofNullable(queryFactory.selectFrom(studyInfo)
+                .where(studyInfo.repositoryInfo.owner.eq(owner)
+                        .and(studyInfo.repositoryInfo.name.eq(repositoryName)))
+                .fetchOne());
     }
 
 }

--- a/backend/src/main/java/com/example/backend/domain/define/study/member/repository/StudyMemberRepositoryCustom.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/member/repository/StudyMemberRepositoryCustom.java
@@ -31,4 +31,7 @@ public interface StudyMemberRepositoryCustom {
 
     // StudyInfoId를 통해 승인 대기중인 멤버들의 가입신청 목록을 가져온다.
     List<StudyMemberApplyResponse> findStudyApplyListByStudyInfoId_CursorPaging(Long studyInfoId, Long cursorIdx, Long limit);
+
+    // GitHubId와 StudyInfoId를 통해 사용자가 해당 스터디의 활동중인 멤버인지 판별한다.
+    boolean existsStudyMemberByGithubIdAndStudyInfoId(String githubId, Long studyInfoId);
 }

--- a/backend/src/main/java/com/example/backend/domain/define/study/member/repository/StudyMemberRepositoryImpl.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/member/repository/StudyMemberRepositoryImpl.java
@@ -145,4 +145,15 @@ public class StudyMemberRepositoryImpl implements StudyMemberRepositoryCustom {
                 .fetch();
 
     }
+
+    @Override
+    public boolean existsStudyMemberByGithubIdAndStudyInfoId(String githubId, Long studyInfoId) {
+        return queryFactory.selectOne()
+                .from(studyMember)
+                .join(user).on(user.id.eq(studyMember.userId))
+                .where(user.githubId.eq(githubId)
+                        .and(studyMember.studyInfoId.eq(studyInfoId))
+                        .and(studyMember.status.eq(StudyMemberStatus.STUDY_ACTIVE)))
+                .fetchFirst() != null;
+    }
 }

--- a/backend/src/main/java/com/example/backend/domain/define/study/todo/mapping/repository/StudyTodoMappingRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/todo/mapping/repository/StudyTodoMappingRepository.java
@@ -14,4 +14,6 @@ public interface StudyTodoMappingRepository extends JpaRepository<StudyTodoMappi
     List<StudyTodoMapping> findByTodoId(Long todoId);
 
     List<StudyTodoMapping> findByUserId(Long userId);
+
+    Optional<StudyTodoMapping> findByTodoIdAndUserId(Long todoId, Long UserId);
 }

--- a/backend/src/main/java/com/example/backend/domain/define/study/todo/mapping/repository/StudyTodoMappingRepositoryCustom.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/todo/mapping/repository/StudyTodoMappingRepositoryCustom.java
@@ -1,8 +1,11 @@
 package com.example.backend.domain.define.study.todo.mapping.repository;
 
 import com.example.backend.domain.define.study.todo.mapping.StudyTodoMapping;
+import com.example.backend.domain.define.study.todo.mapping.constant.StudyTodoStatus;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface StudyTodoMappingRepositoryCustom {
 
@@ -11,4 +14,8 @@ public interface StudyTodoMappingRepositoryCustom {
 
     // todoId로 해당 To-do를 완료한 인원수를 조회한다.
     int findCompleteTodoMappingCountByTodoId(Long todoId);
+
+    // userId와 todoId로 StudyTodoMapping 상태를 업데이트한다.
+    boolean updateByUserIdAndTodoId(Long userId, Long todoId, StudyTodoStatus updateStatus);
+
 }

--- a/backend/src/main/java/com/example/backend/domain/define/study/todo/mapping/repository/StudyTodoMappingRepositoryImpl.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/todo/mapping/repository/StudyTodoMappingRepositoryImpl.java
@@ -1,15 +1,25 @@
 package com.example.backend.domain.define.study.todo.mapping.repository;
 
+import com.example.backend.domain.define.study.todo.info.StudyTodo;
 import com.example.backend.domain.define.study.todo.mapping.StudyTodoMapping;
 import com.example.backend.domain.define.study.todo.mapping.constant.StudyTodoStatus;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.querydsl.core.Tuple;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
+import static com.example.backend.domain.define.account.user.QUser.user;
+import static com.example.backend.domain.define.study.todo.info.QStudyTodo.studyTodo;
 import static com.example.backend.domain.define.study.todo.mapping.QStudyTodoMapping.studyTodoMapping;
+import static com.example.backend.domain.define.study.todo.mapping.constant.StudyTodoStatus.*;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class StudyTodoMappingRepositoryImpl implements StudyTodoMappingRepositoryCustom {
@@ -30,8 +40,30 @@ public class StudyTodoMappingRepositoryImpl implements StudyTodoMappingRepositor
                 .select(studyTodoMapping.count())
                 .from(studyTodoMapping)
                 .where(studyTodoMapping.todoId.eq(todoId)
-                        .and(studyTodoMapping.status.eq(StudyTodoStatus.TODO_COMPLETE)))
+                        .and(studyTodoMapping.status.eq(TODO_COMPLETE)))
                 .fetchOne()
                 .intValue();
+    }
+
+    @Override
+    @Transactional
+    public boolean updateByUserIdAndTodoId(Long userId, Long todoId, StudyTodoStatus updateStatus) {
+        StudyTodoMapping todoMapping = queryFactory.selectFrom(studyTodoMapping)
+                .where(studyTodoMapping.userId.eq(userId)
+                        .and(studyTodoMapping.todoId.eq(todoId)))
+                .fetchOne();
+
+        if (todoMapping == null) return false;
+
+        // 같은 투두에 두번째 업데이트일 경우 첫번째 업데이트 시의 Status를 유지한다.
+        if (todoMapping.getStatus() != TODO_INCOMPLETE) return true;
+
+        // 투두 지각 여부 업데이트
+        long updatedRows = queryFactory.update(studyTodoMapping)
+                .set(studyTodoMapping.status, updateStatus)
+                .where(studyTodoMapping.id.eq(todoMapping.getId()))
+                .execute();
+
+        return updatedRows > 0;
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/define/study/todo/repository/StudyTodoRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/todo/repository/StudyTodoRepository.java
@@ -18,4 +18,6 @@ public interface StudyTodoRepository extends JpaRepository<StudyTodo, Long>, Stu
 
     List<StudyTodo> findByStudyInfoIdAndTodoDateAfter(Long studyInfoId, LocalDate date);
 
+    Optional<StudyTodo> findByTodoCode(String todoCode);
+
 }

--- a/backend/src/main/java/com/example/backend/webhook/api/controller/WebhookController.java
+++ b/backend/src/main/java/com/example/backend/webhook/api/controller/WebhookController.java
@@ -1,0 +1,31 @@
+package com.example.backend.webhook.api.controller;
+
+import com.example.backend.webhook.api.controller.request.WebhookPayload;
+import com.example.backend.webhook.api.service.WebhookService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/webhook")
+public class WebhookController {
+
+    private final WebhookService webhookService;
+
+    @PostMapping("/commit")
+    public ResponseEntity<Void> handleCommitWebhook(@RequestBody @Valid WebhookPayload payload) {
+
+        webhookService.handleCommit(payload);
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+}

--- a/backend/src/main/java/com/example/backend/webhook/api/controller/request/WebhookPayload.java
+++ b/backend/src/main/java/com/example/backend/webhook/api/controller/request/WebhookPayload.java
@@ -1,9 +1,11 @@
 package com.example.backend.webhook.api.controller.request;
 
 import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
 
 import java.time.LocalDate;
 
+@Builder
 public record WebhookPayload(
         String commitId,
         String message,

--- a/backend/src/main/java/com/example/backend/webhook/api/controller/request/WebhookPayload.java
+++ b/backend/src/main/java/com/example/backend/webhook/api/controller/request/WebhookPayload.java
@@ -1,0 +1,15 @@
+package com.example.backend.webhook.api.controller.request;
+
+import jakarta.validation.constraints.Pattern;
+
+import java.time.LocalDate;
+
+public record WebhookPayload(
+        String commitId,
+        String message,
+        String username,
+        @Pattern(regexp = "^.+/.+$", message = "Repository full name must be in the format 'username/repository'")
+        String repositoryFullName,
+        LocalDate commitDate
+) {}
+

--- a/backend/src/main/java/com/example/backend/webhook/api/service/WebhookService.java
+++ b/backend/src/main/java/com/example/backend/webhook/api/service/WebhookService.java
@@ -1,0 +1,133 @@
+package com.example.backend.webhook.api.service;
+
+import com.example.backend.common.exception.ExceptionMessage;
+import com.example.backend.common.exception.convention.ConventionException;
+import com.example.backend.common.exception.member.MemberException;
+import com.example.backend.common.exception.study.StudyInfoException;
+import com.example.backend.common.exception.todo.TodoException;
+import com.example.backend.common.exception.user.UserException;
+import com.example.backend.domain.define.account.user.User;
+import com.example.backend.domain.define.account.user.repository.UserRepository;
+import com.example.backend.domain.define.study.commit.StudyCommit;
+import com.example.backend.domain.define.study.commit.constant.CommitStatus;
+import com.example.backend.domain.define.study.commit.repository.StudyCommitRepository;
+import com.example.backend.domain.define.study.info.StudyInfo;
+import com.example.backend.domain.define.study.info.repository.StudyInfoRepository;
+import com.example.backend.domain.define.study.member.repository.StudyMemberRepository;
+import com.example.backend.domain.define.study.todo.info.StudyTodo;
+import com.example.backend.domain.define.study.todo.mapping.constant.StudyTodoStatus;
+import com.example.backend.domain.define.study.todo.mapping.repository.StudyTodoMappingRepository;
+import com.example.backend.domain.define.study.todo.repository.StudyTodoRepository;
+import com.example.backend.webhook.api.controller.request.WebhookPayload;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.regex.Pattern;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class WebhookService {
+    private final static Pattern DEFAULT_CONVENTION_PATTERN = Pattern.compile("^[a-zA-Z0-9]{6} .*");
+    private final static int TODO_CODE_START_INDEX = 0;
+    private final static int TODO_CODE_END_INDEX = 6;
+
+    private final StudyInfoRepository studyInfoRepository;
+    private final StudyMemberRepository studyMemberRepository;
+    private final StudyTodoMappingRepository studyTodoMappingRepository;
+    private final StudyCommitRepository studyCommitRepository;
+    private final StudyTodoRepository studyTodoRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void handleCommit(WebhookPayload payload) {
+
+        // 커밋 필터링
+        if (!checkConvention(payload.message())) {
+            log.warn(">>>> {} : {} <<<<", payload.message(), ExceptionMessage.CONVENTION_NOT_MATCHED.getText());
+            throw new ConventionException(ExceptionMessage.CONVENTION_NOT_MATCHED);
+        }
+
+        // 스터디 특정
+        StudyInfo study = getStudyByPayLoad(payload.repositoryFullName());
+
+        // 투두 특정
+        StudyTodo todo = getTodoByPayLoad(payload.message());
+
+        // 사용자 특정
+        User user = getUserByPayLoad(payload.username());
+
+        // 권한 검증
+        if (!studyMemberRepository.existsStudyMemberByUserIdAndStudyInfoId(user.getId(), study.getId())) {
+            log.warn(">>>> Github ID: {} {} <<<<", payload.username(), ExceptionMessage.STUDY_NOT_ACTIVE_MEMBER.getText());
+            throw new MemberException(ExceptionMessage.STUDY_NOT_ACTIVE_MEMBER);
+        }
+
+        //  커밋, 투두 정보 업데이트
+        updateCommitAndTodoMappingStatus(user.getId(), study.getId(), todo, payload);
+    }
+
+    private User getUserByPayLoad(String githubId) {
+        return userRepository.findByGithubId(githubId).orElseThrow(() -> {
+            log.warn(">>>> {} : {} <<<<", githubId, ExceptionMessage.USER_NOT_FOUND.getText());
+            throw new UserException(ExceptionMessage.USER_NOT_FOUND);
+        });
+    }
+
+    private StudyTodo getTodoByPayLoad(String message) {
+        // 투두 코드 추출
+        String todoCode = message.substring(TODO_CODE_START_INDEX, TODO_CODE_END_INDEX);
+
+        // 투두 특정
+        return studyTodoRepository.findByTodoCode(todoCode).orElseThrow(() -> {
+            log.warn(">>>> {} : {} <<<<", todoCode, ExceptionMessage.TODO_NOT_FOUND.getText());
+            throw new TodoException(ExceptionMessage.TODO_NOT_FOUND);
+        });
+    }
+
+    private StudyInfo getStudyByPayLoad(String repositoryFullName) {
+        // 레포지토리 owner, name 추출
+        String[] repoInfo = repositoryFullName.split("/");
+        String repoOwner = repoInfo[0];
+        String repoName = repoInfo[1];
+
+        // 스터디 특정
+        return studyInfoRepository.findByRepositoryFullName(repoOwner, repoName).orElseThrow(() -> {
+            log.warn(">>>> {} : {} <<<<", repositoryFullName, ExceptionMessage.STUDY_INFO_NOT_FOUND.getText());
+            throw new StudyInfoException(ExceptionMessage.STUDY_INFO_NOT_FOUND);
+        });
+    }
+
+    private boolean checkConvention(String commitMsg) {
+        // 커밋 메세지가 정규식과 일치하는지 반환
+        return DEFAULT_CONVENTION_PATTERN.matcher(commitMsg).matches();
+    }
+
+    private void updateCommitAndTodoMappingStatus(Long userId, Long studyId, StudyTodo todo, WebhookPayload payload) {
+
+        // 지각 여부 체크
+        StudyTodoStatus updateStatus = payload.commitDate().isAfter(todo.getTodoDate()) ?
+                StudyTodoStatus.TODO_OVERDUE : StudyTodoStatus.TODO_COMPLETE;
+
+        // 투두 mapping 상태 업데이트
+        if (!studyTodoMappingRepository.updateByUserIdAndTodoId(userId, todo.getId(), updateStatus)) {
+            log.warn(">>>> Todo Code: {} {} <<<<", todo.getTodoCode(), ExceptionMessage.STUDY_TODO_MAPPING_NOT_FOUND);
+            throw new TodoException(ExceptionMessage.STUDY_TODO_MAPPING_NOT_FOUND);
+        }
+
+        // 커밋 저장
+        studyCommitRepository.save(StudyCommit.builder()
+                .userId(userId)
+                .studyInfoId(studyId)
+                .studyTodoId(todo.getId())
+                .commitSHA(payload.commitId())
+                .message(payload.message())
+                .commitDate(payload.commitDate())
+                .status(CommitStatus.COMMIT_APPROVAL)
+                .build());
+    }
+
+}

--- a/backend/src/test/java/com/example/backend/auth/api/service/jwt/JwtServiceTest.java
+++ b/backend/src/test/java/com/example/backend/auth/api/service/jwt/JwtServiceTest.java
@@ -233,7 +233,6 @@ class JwtServiceTest extends TestConfig {
         String platformId = savedUser.getPlatformId();
         String platformType = String.valueOf(savedUser.getPlatformType());
 
-
         HashMap<String, String> map = new HashMap<>();
         map.put("role", role);
         map.put("platformId", platformId);
@@ -246,31 +245,5 @@ class JwtServiceTest extends TestConfig {
         // then
         assertThrows(ExpiredJwtException.class,
                 () -> jwtService.isTokenValid(expiredToken, platformId+"_"+platformType));
-    }
-    @Test
-    void 무제한_토큰_만들기() {
-        String key = "3e46db1c90098ae0dc37ea641d11f79f1f3f0f10e2624471e0c643f3696bd12662b6e6623b49440b74447f243c4340bdf9a2532ee557818fbd5258348879afec";
-
-        SecretKey secretKey = Keys.hmacShaKeyFor(Base64.getDecoder().decode(key));
-
-        Map<String, String> claims = new HashMap<>();
-        claims.put("role", "USER");
-        claims.put("platformId", "149556660");
-        claims.put("platformType", "GITHUB");
-
-        String sub = "149556660_GITHUB";
-
-        Date issuedAt = new Date(System.currentTimeMillis());
-        Date expiration = new Date(1735689600000L); // 2025년 1월 1일 (Unix 시간 1735689600000 밀리초)
-
-        String token = Jwts.builder()
-                .setClaims(claims)
-                .setSubject(sub)  // User의 식별자
-                .setIssuedAt(issuedAt)
-                .setExpiration(expiration)
-                .signWith(secretKey)
-                .compact();
-
-        System.out.println("Generated Token: " + token);
     }
 }

--- a/backend/src/test/java/com/example/backend/auth/config/fixture/UserFixture.java
+++ b/backend/src/test/java/com/example/backend/auth/config/fixture/UserFixture.java
@@ -171,4 +171,15 @@ public class UserFixture {
                 .pushAlarmYn(false)
                 .build();
     }
+
+    public static User generateAuthJusung() {
+        return User.builder()
+                .platformId("platformId")
+                .platformType(GITHUB)
+                .role(USER)
+                .name("이주성")
+                .githubId("jusung-c")
+                .profileImageUrl("www.naver.com")
+                .pushAlarmYn(false)
+                .build();    }
 }

--- a/backend/src/test/java/com/example/backend/auth/config/fixture/UserFixture.java
+++ b/backend/src/test/java/com/example/backend/auth/config/fixture/UserFixture.java
@@ -181,5 +181,6 @@ public class UserFixture {
                 .githubId("jusung-c")
                 .profileImageUrl("www.naver.com")
                 .pushAlarmYn(false)
-                .build();    }
+                .build();
+    }
 }

--- a/backend/src/test/java/com/example/backend/auth/config/fixture/UserFixture.java
+++ b/backend/src/test/java/com/example/backend/auth/config/fixture/UserFixture.java
@@ -6,8 +6,7 @@ import com.example.backend.domain.define.account.user.SocialInfo;
 import com.example.backend.domain.define.account.user.User;
 
 import static com.example.backend.domain.define.account.user.constant.UserPlatformType.*;
-import static com.example.backend.domain.define.account.user.constant.UserRole.UNAUTH;
-import static com.example.backend.domain.define.account.user.constant.UserRole.USER;
+import static com.example.backend.domain.define.account.user.constant.UserRole.*;
 
 public class UserFixture {
     public static User generateAuthUser() {
@@ -18,6 +17,17 @@ public class UserFixture {
                 .name("이름")
                 .githubId("깃허브아이디")
                 .profileImageUrl("프로필이미지")
+                .build();
+    }
+
+    public static User generateAdminUser() {
+        return User.builder()
+                .platformId("111")
+                .platformType(GITHUB)
+                .role(ADMIN)
+                .name("관리자")
+                .githubId("관리자")
+                .profileImageUrl("관리자")
                 .build();
     }
 

--- a/backend/src/test/java/com/example/backend/domain/define/study/info/repository/StudyInfoRepositoryTest.java
+++ b/backend/src/test/java/com/example/backend/domain/define/study/info/repository/StudyInfoRepositoryTest.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 
 import static com.example.backend.domain.define.study.info.StudyInfoFixture.createDefaultStudyInfoList;
@@ -293,5 +294,33 @@ class StudyInfoRepositoryTest extends TestConfig {
             assertTrue(currentCreatedDateTime.compareTo(previousCreatedDateTime) <= 0);
             previousCreatedDateTime = currentCreatedDateTime;
         }
+    }
+
+    @Test
+    void 레포지토리_정보를_이용해_스터디_조회_성공_테스트() {
+        // given
+        User savedUser = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(savedUser.getId()));
+
+        // when
+        StudyInfo findStudy = studyInfoRepository.findByRepositoryFullName(study.getRepositoryInfo().getOwner(), study.getRepositoryInfo().getName()).get();
+
+        // then
+        assertEquals(study.getId(), findStudy.getId());
+    }
+
+    @Test
+    void 레포지토리_정보를_이용해_스터디_조회_실패_테스트() {
+        // given
+        User savedUser = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(savedUser.getId()));
+
+        String invalidName = "invalid-name";
+
+        // when
+        Optional<StudyInfo> findStudy = studyInfoRepository.findByRepositoryFullName(study.getRepositoryInfo().getOwner(), invalidName);
+
+        // then
+        assertTrue(findStudy.isEmpty());
     }
 }

--- a/backend/src/test/java/com/example/backend/domain/define/study/member/repository/StudyMemberRepositoryTest.java
+++ b/backend/src/test/java/com/example/backend/domain/define/study/member/repository/StudyMemberRepositoryTest.java
@@ -140,4 +140,34 @@ class StudyMemberRepositoryTest extends TestConfig {
                 .collect(Collectors.toSet());
         assertTrue(studyInfoIdsFromMembers.containsAll(studyInfoIds));
     }
+
+    @Test
+    void GitHubId와_StudyInfoId를_통해_사용자가_활동중인_멤버인지_판단한다_성공_케이스() {
+        // given
+        User savedUser = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(savedUser.getId()));
+        studyMemberRepository.save(StudyMemberFixture.createDefaultStudyMember(savedUser.getId(), study.getId()));
+
+        // when
+        boolean result = studyMemberRepository.existsStudyMemberByGithubIdAndStudyInfoId(savedUser.getGithubId(), study.getUserId());
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    void GitHubId와_StudyInfoId를_통해_사용자가_활동중인_멤버인지_판단한다_실패_케이스() {
+        // given
+        User savedUser = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(savedUser.getId()));
+        studyMemberRepository.save(StudyMemberFixture.createDefaultStudyMember(savedUser.getId(), study.getId()));
+
+        String invalidGithubId = "invalid";
+
+        // when
+        boolean result = studyMemberRepository.existsStudyMemberByGithubIdAndStudyInfoId(invalidGithubId, study.getUserId());
+
+        // then
+        assertFalse(result);
+    }
 }

--- a/backend/src/test/java/com/example/backend/domain/define/study/member/repository/StudyMemberRepositoryTest.java
+++ b/backend/src/test/java/com/example/backend/domain/define/study/member/repository/StudyMemberRepositoryTest.java
@@ -4,11 +4,14 @@ import com.example.backend.TestConfig;
 import com.example.backend.auth.config.fixture.UserFixture;
 import com.example.backend.domain.define.account.user.User;
 import com.example.backend.domain.define.account.user.repository.UserRepository;
+import com.example.backend.domain.define.study.commit.repository.StudyCommitRepository;
 import com.example.backend.domain.define.study.info.StudyInfo;
 import com.example.backend.domain.define.study.info.StudyInfoFixture;
 import com.example.backend.domain.define.study.info.repository.StudyInfoRepository;
 import com.example.backend.domain.define.study.member.StudyMember;
 import com.example.backend.domain.define.study.member.StudyMemberFixture;
+import com.example.backend.domain.define.study.todo.mapping.repository.StudyTodoMappingRepository;
+import com.example.backend.domain.define.study.todo.repository.StudyTodoRepository;
 import com.example.backend.study.api.controller.info.response.StudyMemberWithUserInfoResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -33,20 +36,32 @@ class StudyMemberRepositoryTest extends TestConfig {
     @Autowired
     private StudyInfoRepository studyInfoRepository;
 
+    @Autowired
+    StudyTodoRepository studyTodoRepository;
+
+    @Autowired
+    StudyTodoMappingRepository studyTodoMappingRepository;
+
+    @Autowired
+    StudyCommitRepository studyCommitRepository;
+
     @AfterEach
     void tearDown() {
         studyMemberRepository.deleteAllInBatch();
         userRepository.deleteAllInBatch();
         studyInfoRepository.deleteAllInBatch();
+        studyTodoRepository.deleteAllInBatch();
+        studyTodoMappingRepository.deleteAllInBatch();
+        studyCommitRepository.deleteAllInBatch();
     }
 
     @Test
     void 해당_유저가_스터디의_활동중인_스터디원인지_확인_스터디원일_경우() {
         // given
-        Long userId = 1L;
-        Long studyInfoId = 1L;
+        User user = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
 
-        StudyMember savedMember = studyMemberRepository.save(StudyMemberFixture.createDefaultStudyMember(userId, studyInfoId));
+        StudyMember savedMember = studyMemberRepository.save(StudyMemberFixture.createDefaultStudyMember(user.getId(), study.getId()));
 
         // when
         assertTrue(studyMemberRepository.existsStudyMemberByUserIdAndStudyInfoId(savedMember.getUserId(), savedMember.getStudyInfoId()));
@@ -55,10 +70,10 @@ class StudyMemberRepositoryTest extends TestConfig {
     @Test
     void 해당_유저가_스터디의_활동중인_스터디원인지_확인_테스트_스터디원이_아닐_경우() {
         // given
-        Long userId = 1L;
-        Long studyInfoId = 1L;
+        User user = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
 
-        StudyMember savedMember = studyMemberRepository.save(StudyMemberFixture.createStudyMemberResigned(userId, studyInfoId));
+        StudyMember savedMember = studyMemberRepository.save(StudyMemberFixture.createStudyMemberResigned(user.getId(), study.getId()));
 
         // when
         assertFalse(studyMemberRepository.existsStudyMemberByUserIdAndStudyInfoId(savedMember.getUserId(), savedMember.getStudyInfoId()));
@@ -67,10 +82,10 @@ class StudyMemberRepositoryTest extends TestConfig {
     @Test
     void 해당_유저가_스터디장일_경우() {
         // given
-        Long userId = 1L;
-        Long studyInfoId = 1L;
+        User user = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
 
-        StudyMember savedMember = studyMemberRepository.save(StudyMemberFixture.createStudyMemberLeader(userId, studyInfoId));
+        StudyMember savedMember = studyMemberRepository.save(StudyMemberFixture.createStudyMemberLeader(user.getId(), study.getId()));
 
         // when
         assertTrue(studyMemberRepository.isStudyLeaderByUserIdAndStudyInfoId(savedMember.getUserId(), savedMember.getStudyInfoId()));
@@ -79,10 +94,10 @@ class StudyMemberRepositoryTest extends TestConfig {
     @Test
     void 해당_유저가_스터디장이_아닐_경우() {
         // given
-        Long userId = 1L;
-        Long studyInfoId = 1L;
+        User user = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
 
-        StudyMember savedMember = studyMemberRepository.save(StudyMemberFixture.createDefaultStudyMember(userId, studyInfoId));
+        StudyMember savedMember = studyMemberRepository.save(StudyMemberFixture.createDefaultStudyMember(user.getId(), study.getId()));
 
         // when
         assertFalse(studyMemberRepository.isStudyLeaderByUserIdAndStudyInfoId(savedMember.getUserId(), savedMember.getStudyInfoId()));
@@ -91,24 +106,25 @@ class StudyMemberRepositoryTest extends TestConfig {
     @Test
     void 해당_스터디의_활동중인_스터디원일_경우() {
         // given
-        Long leaderId = 1L;
-        Long withdrawalId = 2L;
-        Long studyInfoId = 1L;
+        User leader = userRepository.save(UserFixture.generateAuthUser());
+        User withdrawal = userRepository.save(UserFixture.generateKaKaoUser());
 
-        studyMemberRepository.save(StudyMemberFixture.createStudyMemberLeader(leaderId, studyInfoId));
-        studyMemberRepository.save(StudyMemberFixture.createStudyMemberWithdrawal(withdrawalId, studyInfoId));
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(leader.getId()));
+
+        studyMemberRepository.save(StudyMemberFixture.createStudyMemberLeader(leader.getId(), study.getId()));
+        studyMemberRepository.save(StudyMemberFixture.createStudyMemberWithdrawal(withdrawal.getId(), study.getId()));
 
         // when
-        List<StudyMember> activeMembers = studyMemberRepository.findActiveMembersByStudyInfoId(studyInfoId);
+        List<StudyMember> activeMembers = studyMemberRepository.findActiveMembersByStudyInfoId(study.getId());
 
         // then
         assertFalse(activeMembers.isEmpty());
         assertTrue(activeMembers.stream()
-                .anyMatch(member -> member.getUserId().equals(leaderId) &&
-                        member.getStudyInfoId().equals(studyInfoId)));
+                .anyMatch(member -> member.getUserId().equals(leader.getId()) &&
+                        member.getStudyInfoId().equals(study.getId())));
         assertFalse(activeMembers.stream()
-                .anyMatch(member -> member.getUserId().equals(withdrawalId) &&
-                        member.getStudyInfoId().equals(studyInfoId)));
+                .anyMatch(member -> member.getUserId().equals(withdrawal.getId()) &&
+                        member.getStudyInfoId().equals(study.getId())));
     }
     @Test
     void studyInfoIdList를_통해_스터디들의_모든_멤버를_조회(){
@@ -144,12 +160,12 @@ class StudyMemberRepositoryTest extends TestConfig {
     @Test
     void GitHubId와_StudyInfoId를_통해_사용자가_활동중인_멤버인지_판단한다_성공_케이스() {
         // given
-        User savedUser = userRepository.save(UserFixture.generateAuthUser());
-        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(savedUser.getId()));
+        User savedUser = userRepository.save(UserFixture.generateAuthJusung());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateDeletedStudyInfo(savedUser.getId()));
         studyMemberRepository.save(StudyMemberFixture.createDefaultStudyMember(savedUser.getId(), study.getId()));
 
         // when
-        boolean result = studyMemberRepository.existsStudyMemberByGithubIdAndStudyInfoId(savedUser.getGithubId(), study.getUserId());
+        boolean result = studyMemberRepository.existsStudyMemberByGithubIdAndStudyInfoId(savedUser.getGithubId(), study.getId());
 
         // then
         assertTrue(result);

--- a/backend/src/test/java/com/example/backend/domain/define/study/todo/StudyTodoFixture.java
+++ b/backend/src/test/java/com/example/backend/domain/define/study/todo/StudyTodoFixture.java
@@ -7,6 +7,8 @@ import com.example.backend.study.api.controller.todo.request.StudyTodoRequest;
 import com.example.backend.study.api.controller.todo.request.StudyTodoUpdateRequest;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.IntStream;
 
 import static com.example.backend.study.api.service.todo.StudyTodoServiceTest.*;
 
@@ -71,8 +73,8 @@ public class StudyTodoFixture {
                 .build();
     }
 
-    //테스트용 studyTodo List 생성
-    public static StudyTodo createStudyTodoList(Long studyInfoId, String title, String detail, String todoLink, LocalDate todoDate) {
+    // 테스트용 studyTodo 생성
+    public static StudyTodo createStudyTodoCustom(Long studyInfoId, String title, String detail, String todoLink, LocalDate todoDate) {
 
         return StudyTodo.builder()
                 .studyInfoId(studyInfoId)
@@ -104,6 +106,13 @@ public class StudyTodoFixture {
                 .title(expectedTitle)
                 .todoDate(todoDate)
                 .build();
+    }
+
+    public static List<StudyTodo> createStudyTodoList(Long studyId, int count) {
+
+        return IntStream.rangeClosed(1, count)
+                        .mapToObj(i -> createStudyTodo(studyId))
+                .toList();
     }
 
 }

--- a/backend/src/test/java/com/example/backend/domain/define/study/todo/mapping/repository/StudyTodoMappingRepositoryTest.java
+++ b/backend/src/test/java/com/example/backend/domain/define/study/todo/mapping/repository/StudyTodoMappingRepositoryTest.java
@@ -1,0 +1,119 @@
+package com.example.backend.domain.define.study.todo.mapping.repository;
+
+import com.example.backend.TestConfig;
+import com.example.backend.auth.config.fixture.UserFixture;
+import com.example.backend.domain.define.account.user.User;
+import com.example.backend.domain.define.account.user.repository.UserRepository;
+import com.example.backend.domain.define.study.info.StudyInfo;
+import com.example.backend.domain.define.study.info.StudyInfoFixture;
+import com.example.backend.domain.define.study.info.repository.StudyInfoRepository;
+import com.example.backend.domain.define.study.todo.StudyTodoFixture;
+import com.example.backend.domain.define.study.todo.info.StudyTodo;
+import com.example.backend.domain.define.study.todo.mapping.StudyTodoMapping;
+import com.example.backend.domain.define.study.todo.mapping.constant.StudyTodoStatus;
+import com.example.backend.domain.define.study.todo.repository.StudyTodoRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static com.example.backend.domain.define.study.todo.mapping.constant.StudyTodoStatus.TODO_COMPLETE;
+import static com.example.backend.domain.define.study.todo.mapping.constant.StudyTodoStatus.TODO_OVERDUE;
+import static org.junit.jupiter.api.Assertions.*;
+
+class StudyTodoMappingRepositoryTest extends TestConfig {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    StudyInfoRepository studyInfoRepository;
+
+    @Autowired
+    StudyTodoRepository studyTodoRepository;
+
+    @Autowired
+    StudyTodoMappingRepository todoMappingRepository;
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAllInBatch();
+        studyInfoRepository.deleteAllInBatch();
+        studyTodoRepository.deleteAllInBatch();
+        todoMappingRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void 투두_상태_완료_업데이트_테스트() {
+        // given
+        User user = userRepository.save(UserFixture.generateAuthJusung());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
+        StudyTodo todo = studyTodoRepository.save(StudyTodoFixture.createStudyTodo(study.getId()));
+        todoMappingRepository.save(StudyTodoFixture.createStudyTodoMapping(todo.getId(), user.getId()));
+
+        // when
+        boolean result = todoMappingRepository.updateByUserIdAndTodoId(user.getId(), todo.getId(), TODO_COMPLETE);
+
+        // then
+        assertTrue(result); // 업데이트 성공
+
+        StudyTodoMapping todoMapping = todoMappingRepository.findByTodoIdAndUserId(todo.getId(), user.getId()).get();
+        assertEquals(StudyTodoStatus.TODO_COMPLETE, todoMapping.getStatus());
+    }
+
+    @Test
+    void 투두_상태_지각_업데이트_테스트() {
+        // given
+        User user = userRepository.save(UserFixture.generateAuthJusung());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
+        StudyTodo todo = studyTodoRepository.save(StudyTodoFixture.createStudyTodo(study.getId()));
+        todoMappingRepository.save(StudyTodoFixture.createStudyTodoMapping(todo.getId(), user.getId()));
+
+        // when
+        boolean result = todoMappingRepository.updateByUserIdAndTodoId(user.getId(), todo.getId(), TODO_OVERDUE);
+
+        // then
+        assertTrue(result); // 업데이트 성공
+
+        StudyTodoMapping todoMapping = todoMappingRepository.findByTodoIdAndUserId(todo.getId(), user.getId()).get();
+        assertEquals(TODO_OVERDUE, todoMapping.getStatus());
+    }
+
+    @Test
+    void 같은_투두에_두번_커밋_시_투두_매핑은_수정하지_않는다() {
+        // given
+        User user = userRepository.save(UserFixture.generateAuthJusung());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
+        StudyTodo todo = studyTodoRepository.save(StudyTodoFixture.createStudyTodo(study.getId()));
+        todoMappingRepository.save(StudyTodoFixture.createCompleteStudyTodoMapping(todo.getId(), user.getId()));
+
+        // when
+        boolean result = todoMappingRepository.updateByUserIdAndTodoId(user.getId(), todo.getId(), TODO_OVERDUE);
+
+        // then
+        assertTrue(result);
+
+        StudyTodoMapping todoMapping = todoMappingRepository.findByTodoIdAndUserId(todo.getId(), user.getId()).get();
+
+        // 두번째 커밋은 마감일을 넘겼지만 이전 첫번째 커밋은 마감 기한 내에 작성했으므로 COMPLETE 상태를 유지
+        assertEquals(StudyTodoStatus.TODO_COMPLETE, todoMapping.getStatus());
+    }
+
+    @Test
+    void 투두매핑이_조회되지_않는_경우_업데이트되지_않는다() {
+        // given
+        User user = userRepository.save(UserFixture.generateAuthJusung());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
+        StudyTodo todo = studyTodoRepository.save(StudyTodoFixture.createStudyTodo(study.getId()));
+//        todoMappingRepository.save(StudyTodoFixture.createCompleteStudyTodoMapping(todo.getId(), user.getId()));
+
+        // when
+        boolean result = todoMappingRepository.updateByUserIdAndTodoId(user.getId(), todo.getId(), TODO_OVERDUE);
+
+        // then
+        assertFalse(result);
+    }
+
+}

--- a/backend/src/test/java/com/example/backend/domain/define/study/todo/repository/StudyTodoRepositoryTest.java
+++ b/backend/src/test/java/com/example/backend/domain/define/study/todo/repository/StudyTodoRepositoryTest.java
@@ -1,8 +1,14 @@
 package com.example.backend.domain.define.study.todo.repository;
 
 import com.example.backend.TestConfig;
+import com.example.backend.auth.config.fixture.UserFixture;
+import com.example.backend.domain.define.account.user.User;
+import com.example.backend.domain.define.account.user.repository.UserRepository;
 import com.example.backend.domain.define.study.commit.StudyCommitFixture;
 import com.example.backend.domain.define.study.commit.repository.StudyCommitRepository;
+import com.example.backend.domain.define.study.info.StudyInfo;
+import com.example.backend.domain.define.study.info.StudyInfoFixture;
+import com.example.backend.domain.define.study.info.repository.StudyInfoRepository;
 import com.example.backend.domain.define.study.todo.StudyTodoFixture;
 import com.example.backend.domain.define.study.todo.info.StudyTodo;
 import org.junit.jupiter.api.AfterEach;
@@ -22,6 +28,12 @@ public class StudyTodoRepositoryTest extends TestConfig {
     @Autowired
     private StudyCommitRepository studyCommitRepository;
 
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private StudyInfoRepository studyInfoRepository;
+
 
     private final String expectedTitle = "Title";
     private final String expectedDetail = "Detail";
@@ -32,19 +44,24 @@ public class StudyTodoRepositoryTest extends TestConfig {
     void tearDown() {
         studyTodoRepository.deleteAllInBatch();
         studyCommitRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+        studyInfoRepository.deleteAllInBatch();
     }
 
     @Test
     void 커서가_null일_경우_전체_페이지_조회_테스트() {
         // given
         Long cursorIdx = null;
-        Long studyInfoId = 1L;
         Long limit = 3L;
+
+        User user = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
+
 
         // To do 10개 저장
         IntStream.rangeClosed(1, 10).forEach(td -> {
-            StudyTodo studyTodo = studyTodoRepository.save(StudyTodoFixture.createStudyTodoList(
-                    studyInfoId,
+            StudyTodo studyTodo = studyTodoRepository.save(StudyTodoFixture.createStudyTodoCustom(
+                    study.getId(),
                     expectedTitle + td,
                     expectedDetail + td,
                     expectedTodoLink + td,
@@ -54,7 +71,7 @@ public class StudyTodoRepositoryTest extends TestConfig {
             IntStream.rangeClosed(1, 2).forEach(ci -> {
                 studyCommitRepository.save(StudyCommitFixture.createDefaultStudyCommit(
                         1L,
-                        studyInfoId,
+                        study.getId(),
                         studyTodo.getId(),
                         "CommitSHA" + td + ci
                 ));
@@ -62,7 +79,7 @@ public class StudyTodoRepositoryTest extends TestConfig {
         });
 
         // when
-        var response = studyTodoRepository.findStudyTodoListByStudyInfoId_CursorPaging(studyInfoId, cursorIdx, limit);
+        var response = studyTodoRepository.findStudyTodoListByStudyInfoId_CursorPaging(study.getId(), cursorIdx, limit);
 
         // then
         response.forEach(r -> {
@@ -76,42 +93,18 @@ public class StudyTodoRepositoryTest extends TestConfig {
 
     @Test
     void 커서가_null이_아닌경우_전체_페이지_조회_테스트() {
-
         // given
-        Long cursorIdx = 5L;
-        Long studyInfoId = 1L;
         Long limit = 3L;
+        Long cursorIdx = Long.MAX_VALUE;
+
+        User user = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
 
         // To do 10개 저장
-        IntStream.rangeClosed(1, 10).forEach(td -> {
-            StudyTodo studyTodo = studyTodoRepository.save(StudyTodoFixture.createStudyTodoList(
-                    studyInfoId,
-                    expectedTitle + td,
-                    expectedDetail + td,
-                    expectedTodoLink + td,
-                    expectedTodoDate.plusDays(td)
-            ));
-            // 각 To do에 Commit 2개씩 저장
-            IntStream.rangeClosed(1, 2).forEach(ci -> {
-                studyCommitRepository.save(StudyCommitFixture.createDefaultStudyCommit(
-                        1L,
-                        studyInfoId,
-                        studyTodo.getId(),
-                        "CommitSHA" + td + ci
-                ));
-            });
-        });
+        studyTodoRepository.saveAll(StudyTodoFixture.createStudyTodoList(study.getId(), 5));
 
-        // when
-        var response = studyTodoRepository.findStudyTodoListByStudyInfoId_CursorPaging(studyInfoId, cursorIdx, limit);
+        var response = studyTodoRepository.findStudyTodoListByStudyInfoId_CursorPaging(study.getId(), cursorIdx, limit);
 
-        // then
         assertEquals(limit, response.size());
-        assertEquals(expectedTitle + "4", response.get(0).getTitle());
-        assertEquals(2, response.get(0).getCommits().size()); // 첫 번째 To do의 Commit 개수 확인
-        assertEquals(expectedTitle + "3", response.get(1).getTitle());
-        assertEquals(2, response.get(1).getCommits().size()); // 두 번째 To do의 Commit 개수 확인
-        assertEquals(expectedTitle + "2", response.get(2).getTitle());
-        assertEquals(2, response.get(2).getCommits().size()); // 세 번째 To do의 Commit 개수 확인
     }
 }

--- a/backend/src/test/java/com/example/backend/study/api/service/commit/StudyCommitServiceTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/service/commit/StudyCommitServiceTest.java
@@ -68,8 +68,8 @@ class StudyCommitServiceTest extends TestConfig {
         studyCommitRepository.deleteAllInBatch();
         studyInfoRepository.deleteAllInBatch();
         studyTodoRepository.deleteAllInBatch();
-        studyInfoRepository.deleteAllInBatch();
         studyMemberRepository.deleteAllInBatch();
+        studyConventionRepository.deleteAllInBatch();
     }
 
     @Test

--- a/backend/src/test/java/com/example/backend/webhook/api/controller/WebhookControllerTest.java
+++ b/backend/src/test/java/com/example/backend/webhook/api/controller/WebhookControllerTest.java
@@ -1,7 +1,9 @@
 package com.example.backend.webhook.api.controller;
 
 import com.example.backend.MockTestConfig;
-import com.example.backend.auth.api.service.auth.AuthService;
+import com.example.backend.auth.api.service.jwt.JwtService;
+import com.example.backend.common.utils.TokenUtil;
+import com.example.backend.domain.define.account.user.User;
 import com.example.backend.webhook.api.controller.request.WebhookPayload;
 import com.example.backend.webhook.api.service.WebhookService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -11,10 +13,11 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.Map;
+
+import static com.example.backend.auth.config.fixture.UserFixture.generateAdminUser;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -29,14 +32,23 @@ class WebhookControllerTest extends MockTestConfig {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @Autowired
+    private JwtService jwtService;
+
     @Test
     void 웹훅_처리_컨트롤러_성공_테스트() throws Exception {
         // given
+        User admin = generateAdminUser();
+
+        Map<String, String> map = TokenUtil.createTokenMap(admin);
+        String accessToken = jwtService.generateAccessToken(map, admin);
+
         doNothing().when(webhookService).handleCommit(any(WebhookPayload.class));
 
         // when
         mockMvc.perform(post("/webhook/commit")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .header(AUTHORIZATION, createAuthorizationHeader(accessToken))
                         .content(objectMapper.writeValueAsString(WebhookPayload.builder().build())))
 
                 // then
@@ -48,6 +60,11 @@ class WebhookControllerTest extends MockTestConfig {
     @Test
     void 웹훅_처리_컨트롤러_실패_테스트() throws Exception {
         // given
+        User admin = generateAdminUser();
+
+        Map<String, String> map = TokenUtil.createTokenMap(admin);
+        String accessToken = jwtService.generateAccessToken(map, admin);
+
         // 레포지토리 형식 미준수
         WebhookPayload payload = WebhookPayload.builder().repositoryFullName("invalid").build();
 
@@ -56,6 +73,7 @@ class WebhookControllerTest extends MockTestConfig {
         // when
         mockMvc.perform(post("/webhook/commit")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .header(AUTHORIZATION, createAuthorizationHeader(accessToken))
                         .content(objectMapper.writeValueAsString(payload)))
 
                 // then

--- a/backend/src/test/java/com/example/backend/webhook/api/controller/WebhookControllerTest.java
+++ b/backend/src/test/java/com/example/backend/webhook/api/controller/WebhookControllerTest.java
@@ -1,0 +1,66 @@
+package com.example.backend.webhook.api.controller;
+
+import com.example.backend.MockTestConfig;
+import com.example.backend.auth.api.service.auth.AuthService;
+import com.example.backend.webhook.api.controller.request.WebhookPayload;
+import com.example.backend.webhook.api.service.WebhookService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class WebhookControllerTest extends MockTestConfig {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private WebhookService webhookService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void 웹훅_처리_컨트롤러_성공_테스트() throws Exception {
+        // given
+        doNothing().when(webhookService).handleCommit(any(WebhookPayload.class));
+
+        // when
+        mockMvc.perform(post("/webhook/commit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(WebhookPayload.builder().build())))
+
+                // then
+                .andExpect(status().isCreated())
+                .andDo(print());
+
+    }
+
+    @Test
+    void 웹훅_처리_컨트롤러_실패_테스트() throws Exception {
+        // given
+        // 레포지토리 형식 미준수
+        WebhookPayload payload = WebhookPayload.builder().repositoryFullName("invalid").build();
+
+        doNothing().when(webhookService).handleCommit(any(WebhookPayload.class));
+
+        // when
+        mockMvc.perform(post("/webhook/commit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+
+                // then
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+
+    }
+}

--- a/backend/src/test/java/com/example/backend/webhook/api/service/WebhookServiceTest.java
+++ b/backend/src/test/java/com/example/backend/webhook/api/service/WebhookServiceTest.java
@@ -160,7 +160,7 @@ class WebhookServiceTest extends TestConfig {
         StudyTodoMapping mapping = studyTodoMappingRepository.findByTodoIdAndUserId(todo.getId(), user.getId()).get();
 
         // then
-        assertEquals(TODO_OVERDUE, mapping.getStatus());
+        assertEquals(TODO_COMPLETE, mapping.getStatus());
         assertEquals(commitId, commit.getCommitSHA());
         assertEquals(user.getId(), commit.getUserId());
     }

--- a/backend/src/test/java/com/example/backend/webhook/api/service/WebhookServiceTest.java
+++ b/backend/src/test/java/com/example/backend/webhook/api/service/WebhookServiceTest.java
@@ -1,0 +1,289 @@
+package com.example.backend.webhook.api.service;
+
+import com.example.backend.TestConfig;
+import com.example.backend.auth.config.fixture.UserFixture;
+import com.example.backend.common.exception.ExceptionMessage;
+import com.example.backend.common.exception.convention.ConventionException;
+import com.example.backend.common.exception.member.MemberException;
+import com.example.backend.common.exception.study.StudyInfoException;
+import com.example.backend.common.exception.todo.TodoException;
+import com.example.backend.common.exception.user.UserException;
+import com.example.backend.domain.define.account.user.User;
+import com.example.backend.domain.define.account.user.repository.UserRepository;
+import com.example.backend.domain.define.study.commit.StudyCommit;
+import com.example.backend.domain.define.study.commit.repository.StudyCommitRepository;
+import com.example.backend.domain.define.study.info.StudyInfo;
+import com.example.backend.domain.define.study.info.StudyInfoFixture;
+import com.example.backend.domain.define.study.info.repository.StudyInfoRepository;
+import com.example.backend.domain.define.study.member.StudyMember;
+import com.example.backend.domain.define.study.member.StudyMemberFixture;
+import com.example.backend.domain.define.study.member.repository.StudyMemberRepository;
+import com.example.backend.domain.define.study.todo.StudyTodoFixture;
+import com.example.backend.domain.define.study.todo.info.StudyTodo;
+import com.example.backend.domain.define.study.todo.mapping.StudyTodoMapping;
+import com.example.backend.domain.define.study.todo.mapping.constant.StudyTodoStatus;
+import com.example.backend.domain.define.study.todo.mapping.repository.StudyTodoMappingRepository;
+import com.example.backend.domain.define.study.todo.repository.StudyTodoRepository;
+import com.example.backend.webhook.api.controller.request.WebhookPayload;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+
+import static com.example.backend.domain.define.study.todo.mapping.constant.StudyTodoStatus.TODO_COMPLETE;
+import static com.example.backend.domain.define.study.todo.mapping.constant.StudyTodoStatus.TODO_OVERDUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class WebhookServiceTest extends TestConfig {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    StudyCommitRepository studyCommitRepository;
+
+    @Autowired
+    StudyInfoRepository studyInfoRepository;
+
+    @Autowired
+    StudyTodoRepository studyTodoRepository;
+
+    @Autowired
+    StudyMemberRepository studyMemberRepository;
+
+    @Autowired
+    StudyTodoMappingRepository studyTodoMappingRepository;
+
+    @Autowired
+    WebhookService webhookService;
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAllInBatch();
+        studyCommitRepository.deleteAllInBatch();
+        studyInfoRepository.deleteAllInBatch();
+        studyTodoRepository.deleteAllInBatch();
+        studyMemberRepository.deleteAllInBatch();
+        studyTodoMappingRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void 마감일_지킨_커밋_처리_성공_테스트() {
+        // given
+        User user = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
+        StudyMember member = studyMemberRepository.save(StudyMemberFixture.createDefaultStudyMember(user.getId(), study.getId()));
+        StudyTodo todo = studyTodoRepository.save(StudyTodoFixture.createStudyTodo(study.getId()));
+        StudyTodoMapping todoMapping = studyTodoMappingRepository.save(StudyTodoFixture.createStudyTodoMapping(todo.getId(), user.getId()));
+
+        String commitId = "123";
+        String message = todo.getTodoCode() + " test commit";
+        String username = user.getGithubId();
+        String repositoryFullName = study.getRepositoryInfo().getOwner() + "/" + study.getRepositoryInfo().getName();
+
+        // 마감일 지킨 커밋
+        LocalDate commitDate = todo.getTodoDate().minusDays(1);
+
+        WebhookPayload payload = new WebhookPayload(commitId, message, username, repositoryFullName, commitDate);
+
+        // when
+        webhookService.handleCommit(payload);
+
+        // when
+        StudyCommit commit = studyCommitRepository.findByStudyTodoIdAndUserId(todo.getId(), user.getId()).get();
+        StudyTodoMapping mapping = studyTodoMappingRepository.findByTodoIdAndUserId(todo.getId(), user.getId()).get();
+
+        // then
+        assertEquals(TODO_COMPLETE, mapping.getStatus());
+        assertEquals(commitId, commit.getCommitSHA());
+        assertEquals(user.getId(), commit.getUserId());
+    }
+
+    @Test
+    void 지각한_커밋_처리_성공_테스트() {
+        // given
+        User user = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
+        StudyMember member = studyMemberRepository.save(StudyMemberFixture.createDefaultStudyMember(user.getId(), study.getId()));
+        StudyTodo todo = studyTodoRepository.save(StudyTodoFixture.createStudyTodo(study.getId()));
+        StudyTodoMapping todoMapping = studyTodoMappingRepository.save(StudyTodoFixture.createStudyTodoMapping(todo.getId(), user.getId()));
+
+        String commitId = "123";
+        String message = todo.getTodoCode() + " test commit";
+        String username = user.getGithubId();
+        String repositoryFullName = study.getRepositoryInfo().getOwner() + "/" + study.getRepositoryInfo().getName();
+
+        // 지각한 커밋
+        LocalDate commitDate = todo.getTodoDate().plusDays(1);
+
+        WebhookPayload payload = new WebhookPayload(commitId, message, username, repositoryFullName, commitDate);
+
+        // when
+        webhookService.handleCommit(payload);
+
+        // when
+        StudyCommit commit = studyCommitRepository.findByStudyTodoIdAndUserId(todo.getId(), user.getId()).get();
+        StudyTodoMapping mapping = studyTodoMappingRepository.findByTodoIdAndUserId(todo.getId(), user.getId()).get();
+
+        // then
+        assertEquals(TODO_OVERDUE, mapping.getStatus());
+        assertEquals(commitId, commit.getCommitSHA());
+        assertEquals(user.getId(), commit.getUserId());
+    }
+
+    @Test
+    void 이미_커밋했던_투두에_다시_커밋했을_때_투두_상태_변화_없음() {
+        // given
+        User user = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
+        StudyMember member = studyMemberRepository.save(StudyMemberFixture.createDefaultStudyMember(user.getId(), study.getId()));
+        StudyTodo todo = studyTodoRepository.save(StudyTodoFixture.createStudyTodo(study.getId()));
+
+        // 이미 완료 상태의 투두 상태
+        StudyTodoMapping todoMapping = studyTodoMappingRepository.save(StudyTodoFixture.createCompleteStudyTodoMapping(todo.getId(), user.getId()));
+
+        String commitId = "123";
+        String message = todo.getTodoCode() + " test commit";
+        String username = user.getGithubId();
+        String repositoryFullName = study.getRepositoryInfo().getOwner() + "/" + study.getRepositoryInfo().getName();
+        LocalDate commitDate = todo.getTodoDate().plusDays(1);
+
+        WebhookPayload payload = new WebhookPayload(commitId, message, username, repositoryFullName, commitDate);
+
+        // when
+        webhookService.handleCommit(payload);
+
+        // when
+        StudyCommit commit = studyCommitRepository.findByStudyTodoIdAndUserId(todo.getId(), user.getId()).get();
+        StudyTodoMapping mapping = studyTodoMappingRepository.findByTodoIdAndUserId(todo.getId(), user.getId()).get();
+
+        // then
+        assertEquals(TODO_OVERDUE, mapping.getStatus());
+        assertEquals(commitId, commit.getCommitSHA());
+        assertEquals(user.getId(), commit.getUserId());
+    }
+
+    @Test
+    void 커밋_메세지가_컨벤션을_지키지_않으면_커밋_처리_실패() {
+        // given
+        User user = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
+        StudyMember member = studyMemberRepository.save(StudyMemberFixture.createDefaultStudyMember(user.getId(), study.getId()));
+        StudyTodo todo = studyTodoRepository.save(StudyTodoFixture.createStudyTodo(study.getId()));
+        StudyTodoMapping todoMapping = studyTodoMappingRepository.save(StudyTodoFixture.createStudyTodoMapping(todo.getId(), user.getId()));
+
+        String commitId = "123";
+        String username = user.getGithubId();
+        String repositoryFullName = study.getRepositoryInfo().getOwner() + "/" + study.getRepositoryInfo().getName();
+        LocalDate commitDate = todo.getTodoDate().minusDays(1);
+
+        // 컨벤션을 지키지 않은 커밋 메세지
+        String message = "Invalid-message";
+
+        WebhookPayload payload = new WebhookPayload(commitId, message, username, repositoryFullName, commitDate);
+
+        // when
+        ConventionException e = assertThrows(ConventionException.class, () -> webhookService.handleCommit(payload));
+        assertEquals(ExceptionMessage.CONVENTION_NOT_MATCHED.getText(), e.getMessage());
+    }
+
+    @Test
+    void 페이로드에_해당하는_유저가_없으면_커밋_처리_실패() {
+        // given
+        User user = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
+        StudyMember member = studyMemberRepository.save(StudyMemberFixture.createDefaultStudyMember(user.getId(), study.getId()));
+        StudyTodo todo = studyTodoRepository.save(StudyTodoFixture.createStudyTodo(study.getId()));
+        StudyTodoMapping todoMapping = studyTodoMappingRepository.save(StudyTodoFixture.createStudyTodoMapping(todo.getId(), user.getId()));
+
+        String commitId = "123";
+        String message = todo.getTodoCode() + " test commit";
+        String repositoryFullName = study.getRepositoryInfo().getOwner() + "/" + study.getRepositoryInfo().getName();
+        LocalDate commitDate = todo.getTodoDate().minusDays(1);
+
+        // 존재하지 않는 유저(깃허브계정)
+        String username = "invalid";
+
+        WebhookPayload payload = new WebhookPayload(commitId, message, username, repositoryFullName, commitDate);
+
+        // when
+        UserException e = assertThrows(UserException.class, () -> webhookService.handleCommit(payload));
+        assertEquals(ExceptionMessage.USER_NOT_FOUND.getText(), e.getMessage());
+    }
+
+    @Test
+    void 페이로드에_해당하는_스터디가_없으면_커밋_처리_실패() {
+        // given
+        User user = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
+        StudyMember member = studyMemberRepository.save(StudyMemberFixture.createDefaultStudyMember(user.getId(), study.getId()));
+        StudyTodo todo = studyTodoRepository.save(StudyTodoFixture.createStudyTodo(study.getId()));
+        StudyTodoMapping todoMapping = studyTodoMappingRepository.save(StudyTodoFixture.createStudyTodoMapping(todo.getId(), user.getId()));
+
+        String commitId = "123";
+        String username = user.getGithubId();
+        String message = todo.getTodoCode() + " test commit";
+        LocalDate commitDate = todo.getTodoDate().minusDays(1);
+
+        // 존재하지 않는 스터디
+        String repositoryFullName = "test/test";
+
+        WebhookPayload payload = new WebhookPayload(commitId, message, username, repositoryFullName, commitDate);
+
+        // when
+        StudyInfoException e = assertThrows(StudyInfoException.class, () -> webhookService.handleCommit(payload));
+        assertEquals(ExceptionMessage.STUDY_INFO_NOT_FOUND.getText(), e.getMessage());
+    }
+
+    @Test
+    void 페이로드에_해당하는_투두가_없으면_커밋_처리_실패() {
+        // given
+        User user = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
+        StudyMember member = studyMemberRepository.save(StudyMemberFixture.createDefaultStudyMember(user.getId(), study.getId()));
+        StudyTodo todo = studyTodoRepository.save(StudyTodoFixture.createStudyTodo(study.getId()));
+        StudyTodoMapping todoMapping = studyTodoMappingRepository.save(StudyTodoFixture.createStudyTodoMapping(todo.getId(), user.getId()));
+
+        String commitId = "123";
+        String username = user.getGithubId();
+        String repositoryFullName = study.getRepositoryInfo().getOwner() + "/" + study.getRepositoryInfo().getName();
+        LocalDate commitDate = todo.getTodoDate().minusDays(1);
+
+        // 존재하지 않는 투두
+        String message = "NONONO test commit";
+
+        WebhookPayload payload = new WebhookPayload(commitId, message, username, repositoryFullName, commitDate);
+
+        // when
+        TodoException e = assertThrows(TodoException.class, () -> webhookService.handleCommit(payload));
+        assertEquals(ExceptionMessage.TODO_NOT_FOUND.getText(), e.getMessage());
+    }
+
+    @Test
+    void 커미터가_스터디의_활성화된_멤버가_아닌_경우_커밋_처리_실패() {
+        // given
+        User user = userRepository.save(UserFixture.generateAuthUser());
+        StudyInfo study = studyInfoRepository.save(StudyInfoFixture.generateStudyInfo(user.getId()));
+        StudyTodo todo = studyTodoRepository.save(StudyTodoFixture.createStudyTodo(study.getId()));
+        StudyTodoMapping todoMapping = studyTodoMappingRepository.save(StudyTodoFixture.createStudyTodoMapping(todo.getId(), user.getId()));
+
+        // 강퇴당한 멤버
+        StudyMember member = studyMemberRepository.save(StudyMemberFixture.createStudyMemberResigned(user.getId(), study.getId()));
+
+        String commitId = "123";
+        String message = todo.getTodoCode() + " test commit";
+        String username = user.getGithubId();
+        String repositoryFullName = study.getRepositoryInfo().getOwner() + "/" + study.getRepositoryInfo().getName();
+
+        // 마감일 지킨 커밋
+        LocalDate commitDate = todo.getTodoDate().minusDays(1);
+
+        WebhookPayload payload = new WebhookPayload(commitId, message, username, repositoryFullName, commitDate);
+
+        // when
+        MemberException e = assertThrows(MemberException.class, () -> webhookService.handleCommit(payload));
+        assertEquals(ExceptionMessage.STUDY_NOT_ACTIVE_MEMBER.getText(), e.getMessage());
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#431 

### Pull Request Type
- [x]  새로운 기능 추가
- [ ]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [x]  테스트 추가, 테스트 리팩토링
- [ ]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist
- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용
- 웹훅 api 시큐리티 전부 허용
- 웹훅 데이터 처리 로직 구현

## 💬 리뷰 요구사항
처음에는 단계별로 메서드 분리해서 하려고 했는데 겹치는 조회 쿼리가 많아서 그냥 미리다 조회해두고 단계별로 했어요
이전 로직은 한방에 여러 커밋들을 가져와서 처리했다면 이번엔 커밋마다 하나하나 실시간으로 처리해줘야 하니 쿼리를 더 잘 짜야할 거 같은데 방법을 잘 모르겠네요 🥲 더 나은 방법 있으면 피드백 주세요~

---

투두 매핑 업데이트 시 한 투두에 대해 같은 사람이 다른 풀이법으로 2개의 커밋을 날렸을 시 첫 번째 커밋을 기준으로 지각 여부를 판단하도록 설정했어요.

---

투두 지각 기준이 조금 애매해요. 지금은 커밋 날리면 커밋 날린 시점을 기준으로 지각 여부를 바로 업데이트하고 있는데
커밋 승인/거절 여부에 따라 달라져야 하나 싶기도 하네요
ex) 커밋 승인 대기 상태에서 승인되면 그 때 커밋 시간을 기준으로 지각여부 판단 
    - 팀장이 승인해줄 때까지 커밋했는데도 투두 완료 여부(지각 여부) 업데이트 안됨 -> 팀장 부담

만약 커밋 디폴트 상태를 승인으로 한다면?
    - 커밋 발생시 바로 지각 여부를 업데이트하고 승인이 거절로 바뀔 시 지각 여부 초기화
    - 근데 이것도 뭔가 이상한 느김
