### PR TITLE
[BE] feat(#457): 사용자별 GitHub api 토큰 관리 로직 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/auth/api/service/auth/AuthService.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/auth/AuthService.java
@@ -24,6 +24,7 @@ import com.example.backend.domain.define.refreshToken.RefreshToken;
 import com.example.backend.domain.define.refreshToken.repository.RefreshTokenRepository;
 import com.example.backend.domain.define.study.github.GithubApiToken;
 import com.example.backend.domain.define.study.github.repository.GithubApiTokenRepository;
+import com.example.backend.study.api.service.github.GithubApiTokenService;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,7 +47,7 @@ public class AuthService {
     private final JwtService jwtService;
     private final RefreshTokenService refreshTokenService;
     private final RefreshTokenRepository refreshTokenRepository;
-    private final GithubApiTokenRepository githubApiTokenRepository;
+    private final GithubApiTokenService githubApiTokenService;
 
     @Transactional
     public AuthLoginResponse login(UserPlatformType platformType, String code, String state) {
@@ -75,10 +76,9 @@ public class AuthService {
                     log.info(">>>> [ UNAUTH 권한으로 사용자를 DB에 등록합니다. 이후 회원가입이 필요합니다 ] <<<<");
 
                     User user = userRepository.save(saveUser);
-                    githubApiTokenRepository.save(GithubApiToken.builder()
-                            .userId(user.getId())
-                            .githubApiToken(loginResponse.getGithubApiToken())
-                            .build());
+
+                    // 깃허브 api 토큰 저장
+                    githubApiTokenService.saveToken(loginResponse.getGithubApiToken(), user.getId());
 
                     return user;
                 });

--- a/backend/src/main/java/com/example/backend/common/exception/ExceptionMessage.java
+++ b/backend/src/main/java/com/example/backend/common/exception/ExceptionMessage.java
@@ -85,6 +85,9 @@ public enum ExceptionMessage {
     GITHUB_API_CREATE_REPOSITORY_ERROR ("GitHub 레포지토리 생성 중 오류가 발생했습니다."),
     GITHUB_API_REPOSITORY_ALREADY_EXISTS("해당 이름의 레포지토리가 이미 존재합니다."),
 
+    // GithubApiTokenException
+    GITHUB_API_TOKEN_NOT_EXIST("사용자 id에 해당하는 GithubApiToken이 존재하지 않습니다."),
+
     // CategoryException
     CATEGORY_NOT_FOUND("해당 카테고리를 찾을 수 없습니다."),
 

--- a/backend/src/main/java/com/example/backend/common/exception/github/GithubApiTokenException.java
+++ b/backend/src/main/java/com/example/backend/common/exception/github/GithubApiTokenException.java
@@ -1,0 +1,10 @@
+package com.example.backend.common.exception.github;
+
+import com.example.backend.common.exception.ExceptionMessage;
+import com.example.backend.common.exception.GitudyException;
+
+public class GithubApiTokenException extends GitudyException {
+    public GithubApiTokenException(ExceptionMessage message) {
+        super(message.getText());
+    }
+}

--- a/backend/src/main/java/com/example/backend/domain/define/study/github/GithubApiToken.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/github/GithubApiToken.java
@@ -1,24 +1,14 @@
 package com.example.backend.domain.define.study.github;
 
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
 
-@Getter
-@ToString
-@RedisHash(value = "github")
-@NoArgsConstructor
 @Builder
-public class GithubApiToken {
-    @Id
-    private Long userId;
-    private String githubApiToken;
-
-    public GithubApiToken(Long userId, String githubApiToken) {
-        this.userId = userId;
-        this.githubApiToken = githubApiToken;
-    }
+@RedisHash(value = "githubToken")
+public record GithubApiToken (
+        @Id String githubApiToken,
+        @Indexed Long userId
+){
 }

--- a/backend/src/main/java/com/example/backend/domain/define/study/github/repository/GithubApiTokenRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/github/repository/GithubApiTokenRepository.java
@@ -3,5 +3,14 @@ package com.example.backend.domain.define.study.github.repository;
 import com.example.backend.domain.define.study.github.GithubApiToken;
 import org.springframework.data.repository.CrudRepository;
 
-public interface GithubApiTokenRepository extends CrudRepository<GithubApiToken, Long> {
+import java.util.Optional;
+
+public interface GithubApiTokenRepository extends CrudRepository<GithubApiToken, String> {
+
+    // 사용자 아이디로 토큰 조회
+    Optional<GithubApiToken> findByUserId(Long userId);
+
+    // 사용자의 저장된 토큰이 있는지 확인
+    boolean existsByUserId(Long userId);
+
 }

--- a/backend/src/main/java/com/example/backend/study/api/service/github/GithubApiService.java
+++ b/backend/src/main/java/com/example/backend/study/api/service/github/GithubApiService.java
@@ -22,16 +22,14 @@ import java.util.Map;
 @Transactional(readOnly = true)
 @Service
 public class GithubApiService {
-    @Value("${github.api.token}")
-    private String token;
 
     @Value("${github.api.webhookURL}")
     private String webhookUrl;
 
     // 깃허브 통신을 위한 커넥션 생성
-    public GitHub connectGithub(String token) {
+    public GitHub connectGithub(String githubApiToken) {
         try {
-            GitHub github = new GitHubBuilder().withOAuthToken(token).build();
+            GitHub github = new GitHubBuilder().withOAuthToken(githubApiToken).build();
             github.checkApiUrlValidity();
             log.info(">>>> [ 깃허브 api 연결에 성공하였습니다. ] <<<<");
 
@@ -44,9 +42,9 @@ public class GithubApiService {
     }
 
     // 레포지토리 정보 가져오기
-    public GHRepository getRepository(RepositoryInfo studyInfo) {
+    public GHRepository getRepository(String githubApiToken, RepositoryInfo studyInfo) {
         try {
-            GitHub gitHub = connectGithub(token);
+            GitHub gitHub = connectGithub(githubApiToken);
             return gitHub.getRepository(studyInfo.getOwner() + "/" + studyInfo.getName());
         } catch (IOException e) {
             log.error(">>>> [ {} : {} ] <<<<", ExceptionMessage.GITHUB_API_GET_REPOSITORY_ERROR.getText(), e.getMessage());
@@ -56,9 +54,9 @@ public class GithubApiService {
 
     // 깃허브 레포지토리 생성 메서드
     @Transactional
-    public GHRepository createRepository(RepositoryInfo repoInfo, String description) {
+    public GHRepository createRepository(String githubApiToken, RepositoryInfo repoInfo, String description) {
         try {
-            GitHub gitHub = connectGithub(token);
+            GitHub gitHub = connectGithub(githubApiToken);
 
             // 레포지토리 이름 중복 확인
             if (repositoryExists(gitHub, repoInfo.getOwner() + "/" + repoInfo.getName())) {

--- a/backend/src/main/java/com/example/backend/study/api/service/github/GithubApiTokenService.java
+++ b/backend/src/main/java/com/example/backend/study/api/service/github/GithubApiTokenService.java
@@ -1,5 +1,8 @@
 package com.example.backend.study.api.service.github;
 
+import com.example.backend.common.exception.ExceptionMessage;
+import com.example.backend.common.exception.github.GithubApiException;
+import com.example.backend.common.exception.github.GithubApiTokenException;
 import com.example.backend.domain.define.study.github.GithubApiToken;
 import com.example.backend.domain.define.study.github.repository.GithubApiTokenRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +16,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class GithubApiTokenService {
     private final GithubApiTokenRepository githubApiTokenRepository;
+
+    @Transactional(readOnly = true)
+    public GithubApiToken getToken(Long userId) {
+        return githubApiTokenRepository.findByUserId(userId).orElseThrow(() -> {
+            log.warn(">>>> {} : {} <<<<" , userId, ExceptionMessage.GITHUB_API_TOKEN_NOT_EXIST.getText());
+            throw new GithubApiTokenException(ExceptionMessage.GITHUB_API_TOKEN_NOT_EXIST);
+        });
+    }
 
     // 사용자의 토큰 저장 로직
     @Transactional

--- a/backend/src/main/java/com/example/backend/study/api/service/github/GithubApiTokenService.java
+++ b/backend/src/main/java/com/example/backend/study/api/service/github/GithubApiTokenService.java
@@ -1,0 +1,32 @@
+package com.example.backend.study.api.service.github;
+
+import com.example.backend.domain.define.study.github.GithubApiToken;
+import com.example.backend.domain.define.study.github.repository.GithubApiTokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class GithubApiTokenService {
+    private final GithubApiTokenRepository githubApiTokenRepository;
+
+    // 사용자의 토큰 저장 로직
+    @Transactional
+    public GithubApiToken saveToken(String githubApiToken, Long userId) {
+        // 저장하기 전 이미 토큰이 존재하는지 확인 후 삭제
+        deleteToken(userId);
+
+        return githubApiTokenRepository.save(new GithubApiToken(githubApiToken, userId));
+    }
+
+    // 사용자의 토큰 삭제 로직
+    @Transactional
+    public void deleteToken(Long userId) {
+        githubApiTokenRepository.findByUserId(userId).ifPresent(githubApiTokenRepository::delete);
+    }
+
+}

--- a/backend/src/main/java/com/example/backend/study/api/service/info/StudyInfoService.java
+++ b/backend/src/main/java/com/example/backend/study/api/service/info/StudyInfoService.java
@@ -10,6 +10,8 @@ import com.example.backend.domain.define.study.category.mapping.StudyCategoryMap
 import com.example.backend.domain.define.study.category.mapping.repository.StudyCategoryMappingRepository;
 import com.example.backend.domain.define.study.convention.StudyConvention;
 import com.example.backend.domain.define.study.convention.repository.StudyConventionRepository;
+import com.example.backend.domain.define.study.github.GithubApiToken;
+import com.example.backend.domain.define.study.github.repository.GithubApiTokenRepository;
 import com.example.backend.domain.define.study.info.StudyInfo;
 import com.example.backend.domain.define.study.info.repository.StudyInfoRepository;
 import com.example.backend.domain.define.study.member.StudyMember;
@@ -18,6 +20,7 @@ import com.example.backend.study.api.controller.info.request.StudyInfoRegisterRe
 import com.example.backend.study.api.controller.info.request.StudyInfoUpdateRequest;
 import com.example.backend.study.api.controller.info.response.*;
 import com.example.backend.study.api.service.github.GithubApiService;
+import com.example.backend.study.api.service.github.GithubApiTokenService;
 import com.example.backend.study.api.service.info.response.UserNameAndProfileImageResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,6 +41,7 @@ import static com.example.backend.domain.define.study.member.constant.StudyMembe
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class StudyInfoService {
+    private final GithubApiTokenRepository githubApiTokenRepository;
     private final static String DEFAULT_NAME = "default convention";
     private final static String DEFAULT_CONTENT = "^[a-zA-Z0-9]{6} .*";
 
@@ -49,6 +53,7 @@ public class StudyInfoService {
     private final UserRepository userRepository;
     private final StudyConventionRepository studyConventionRepository;
     private final GithubApiService githubApiService;
+    private final GithubApiTokenService githubApiTokenService;
 
     @Transactional
     public StudyInfoRegisterResponse registerStudy(StudyInfoRegisterRequest request, UserInfoResponse userInfo) {
@@ -69,7 +74,8 @@ public class StudyInfoService {
         registerDefaultConvention(studyInfo.getId());
 
         // github에 스터디 레포지토리 생성
-        githubApiService.createRepository(studyInfo.getRepositoryInfo(), "README.md를 작성해주세요.");
+        GithubApiToken token = githubApiTokenService.getToken(userInfo.getUserId());
+        githubApiService.createRepository(token.githubApiToken(), studyInfo.getRepositoryInfo(), "README.md를 작성해주세요.");
 
         return StudyInfoRegisterResponse.of(studyInfo, categories);
     }

--- a/backend/src/test/java/com/example/backend/auth/api/service/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/example/backend/auth/api/service/auth/AuthServiceTest.java
@@ -68,6 +68,7 @@ class AuthServiceTest extends MockTestConfig {
     @AfterEach
     void tearDown() {
         userRepository.deleteAllInBatch();
+        githubApiTokenRepository.deleteAll();
     }
 
     @Test

--- a/backend/src/test/java/com/example/backend/auth/api/service/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/example/backend/auth/api/service/auth/AuthServiceTest.java
@@ -89,14 +89,14 @@ class AuthServiceTest extends MockTestConfig {
         authService.login(GITHUB, code, state);
 
         User user = userRepository.findByPlatformIdAndPlatformType(platformId, platformType).get();
-        GithubApiToken githubApiToken = githubApiTokenRepository.findById(user.getId()).get();
+        GithubApiToken githubApiToken = githubApiTokenRepository.findByUserId(user.getId()).get();
 
         // then
         assertThat(user).isNotNull();
         assertThat(user.getRole().name()).isEqualTo(UserRole.UNAUTH.name());
 
         // githubApiToken 생성 검증
-        assertThat(githubApiToken.getGithubApiToken()).isEqualTo(token);
+        assertThat(githubApiToken.githubApiToken()).isEqualTo(token);
     }
 
     @Test

--- a/backend/src/test/java/com/example/backend/domain/define/study/github/GithubApiTokenFixture.java
+++ b/backend/src/test/java/com/example/backend/domain/define/study/github/GithubApiTokenFixture.java
@@ -1,0 +1,7 @@
+package com.example.backend.domain.define.study.github;
+
+public class GithubApiTokenFixture {
+    public static GithubApiToken createToken(String token, Long userId) {
+        return new GithubApiToken(token, userId);
+    }
+}

--- a/backend/src/test/java/com/example/backend/domain/define/study/github/repository/GithubApiTokenRepositoryTest.java
+++ b/backend/src/test/java/com/example/backend/domain/define/study/github/repository/GithubApiTokenRepositoryTest.java
@@ -50,11 +50,11 @@ class GithubApiTokenRepositoryTest extends TestConfig {
     @Test
     void 사용자_아이디로_깃허브토큰_조회_테스트() {
         // given
-        User userA = userRepository.save(UserFixture.generateGoogleUser());
         String userAToken = "A";
+        User userA = userRepository.save(UserFixture.generateAuthUserByPlatformId(userAToken));
 
-        User userB = userRepository.save(UserFixture.generateKaKaoUser());
         String userBToken = "B";
+        User userB = userRepository.save(UserFixture.generateAuthUserByPlatformId(userBToken));
 
         githubApiTokenRepository.save(GithubApiTokenFixture.createToken(userAToken, userA.getId()));
         githubApiTokenRepository.save(GithubApiTokenFixture.createToken(userBToken, userB.getId()));

--- a/backend/src/test/java/com/example/backend/study/api/service/github/GithubApiServiceTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/service/github/GithubApiServiceTest.java
@@ -42,6 +42,9 @@ class GithubApiServiceTest extends TestConfig {
     @Value("${github.api.webhookURL}")
     private String webhookUrl;
 
+    @Value("${github.api.token}")
+    private String githubApiToken;
+
     @Autowired
     private GithubApiService githubApiService;
 
@@ -84,7 +87,7 @@ class GithubApiServiceTest extends TestConfig {
                 .build();
 
         // when
-        GHRepository repository = githubApiService.getRepository(repo);
+        GHRepository repository = githubApiService.getRepository(githubApiToken, repo);
 
         // then
         assertAll(
@@ -106,7 +109,7 @@ class GithubApiServiceTest extends TestConfig {
                 .build();
 
         // when
-        GHRepository createdRepository = githubApiService.createRepository(repoInfo, description);
+        GHRepository createdRepository = githubApiService.createRepository(githubApiToken, repoInfo, description);
 
         // then
         assertNotNull(createdRepository);
@@ -133,11 +136,11 @@ class GithubApiServiceTest extends TestConfig {
                 .build();
 
         // 먼저 동일한 이름의 레포지토리를 생성하여 중복 상태를 만듭니다.
-        githubApiService.createRepository(repoInfo, description);
+        githubApiService.createRepository(githubApiToken, repoInfo, description);
 
         // when, then
         GithubApiException exception = assertThrows(GithubApiException.class, () -> {
-            githubApiService.createRepository(repoInfo, description);
+            githubApiService.createRepository(githubApiToken, repoInfo, description);
         });
 
         assertEquals(ExceptionMessage.GITHUB_API_REPOSITORY_ALREADY_EXISTS.getText(), exception.getMessage());

--- a/backend/src/test/java/com/example/backend/study/api/service/github/GithubApiTokenServiceTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/service/github/GithubApiTokenServiceTest.java
@@ -2,15 +2,17 @@ package com.example.backend.study.api.service.github;
 
 import com.example.backend.TestConfig;
 import com.example.backend.auth.config.fixture.UserFixture;
+import com.example.backend.common.exception.ExceptionMessage;
+import com.example.backend.common.exception.github.GithubApiTokenException;
 import com.example.backend.domain.define.account.user.User;
 import com.example.backend.domain.define.account.user.repository.UserRepository;
+import com.example.backend.domain.define.study.github.GithubApiToken;
 import com.example.backend.domain.define.study.github.repository.GithubApiTokenRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 class GithubApiTokenServiceTest extends TestConfig {
     @Autowired
@@ -26,6 +28,17 @@ class GithubApiTokenServiceTest extends TestConfig {
     void tearDown() {
         githubApiTokenRepository.deleteAll();
         userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void 깃허브토큰_조회_실패_테스트() {
+        User user = userRepository.save(UserFixture.generateGoogleUser());
+
+        var e = assertThrows(GithubApiTokenException.class, () -> {
+            githubApiTokenService.getToken(user.getId());
+        });
+
+        assertEquals(ExceptionMessage.GITHUB_API_TOKEN_NOT_EXIST.getText(), e.getMessage());
     }
 
     @Test

--- a/backend/src/test/java/com/example/backend/study/api/service/github/GithubApiTokenServiceTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/service/github/GithubApiTokenServiceTest.java
@@ -1,0 +1,81 @@
+package com.example.backend.study.api.service.github;
+
+import com.example.backend.TestConfig;
+import com.example.backend.auth.config.fixture.UserFixture;
+import com.example.backend.domain.define.account.user.User;
+import com.example.backend.domain.define.account.user.repository.UserRepository;
+import com.example.backend.domain.define.study.github.repository.GithubApiTokenRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class GithubApiTokenServiceTest extends TestConfig {
+    @Autowired
+    private GithubApiTokenService githubApiTokenService;
+
+    @Autowired
+    private GithubApiTokenRepository githubApiTokenRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @AfterEach
+    void tearDown() {
+        githubApiTokenRepository.deleteAll();
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void 토큰_삭제_테스트() {
+        // given
+        User user = userRepository.save(UserFixture.generateGoogleUser());
+        String userToken = "token";
+
+        githubApiTokenService.saveToken(userToken, user.getId());
+
+        // when
+        githubApiTokenService.deleteToken(user.getId());
+
+        // then
+        assertFalse(githubApiTokenRepository.findByUserId(user.getId()).isPresent());
+    }
+
+    @Test
+    void 기존_토큰이_없는_사용자의_토큰을_저장한다() {
+        // given
+        User user = userRepository.save(UserFixture.generateGoogleUser());
+        String userToken = "token";
+
+        // when
+        githubApiTokenService.saveToken(userToken, user.getId());
+        var findToken = githubApiTokenRepository.findById(userToken).get();
+
+        // then
+
+        assertEquals(userToken, findToken.githubApiToken());
+        assertEquals(user.getId(), findToken.userId());
+    }
+
+    @Test
+    void 기존_토큰이_있는_사용자의_토큰을_저장할_경우_기존_토큰을_삭제한_후_저장한다() {
+        // given
+        User user = userRepository.save(UserFixture.generateGoogleUser());
+        String oldToken = "token";
+        String newToken = "newToken";
+
+        // when
+        githubApiTokenService.saveToken(oldToken, user.getId());
+        githubApiTokenService.saveToken(newToken, user.getId());
+
+        var findToken = githubApiTokenRepository.findByUserId(user.getId()).get();
+
+        // then
+        assertFalse(githubApiTokenRepository.findById(oldToken).isPresent());
+        assertEquals(newToken, findToken.githubApiToken());
+        assertEquals(user.getId(), findToken.userId());
+    }
+
+}

--- a/backend/src/test/java/com/example/backend/study/api/service/info/StudyInfoServiceTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/service/info/StudyInfoServiceTest.java
@@ -131,7 +131,7 @@ class StudyInfoServiceTest extends TestConfig {
         assertEquals(expectedConvention, convention.get(0).getContent());
 
         // github api가 작동했는지 확인
-        verify(githubApiService, times(1)).createRepository(any(RepositoryInfo.class), any(String.class));
+        verify(githubApiService, times(1)).createRepository(any(String.class), any(RepositoryInfo.class), any(String.class));
     }
 
 

--- a/backend/src/test/java/com/example/backend/study/api/service/info/StudyInfoServiceTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/service/info/StudyInfoServiceTest.java
@@ -13,6 +13,7 @@ import com.example.backend.domain.define.study.category.mapping.StudyCategoryMap
 import com.example.backend.domain.define.study.category.mapping.repository.StudyCategoryMappingRepository;
 import com.example.backend.domain.define.study.convention.StudyConvention;
 import com.example.backend.domain.define.study.convention.repository.StudyConventionRepository;
+import com.example.backend.domain.define.study.github.GithubApiToken;
 import com.example.backend.domain.define.study.info.StudyInfo;
 import com.example.backend.domain.define.study.info.constant.RepositoryInfo;
 import com.example.backend.domain.define.study.info.constant.StudyStatus;
@@ -25,6 +26,7 @@ import com.example.backend.study.api.controller.info.request.StudyInfoRegisterRe
 import com.example.backend.study.api.controller.info.request.StudyInfoUpdateRequest;
 import com.example.backend.study.api.controller.info.response.*;
 import com.example.backend.study.api.service.github.GithubApiService;
+import com.example.backend.study.api.service.github.GithubApiTokenService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,8 +44,7 @@ import static com.example.backend.domain.define.study.info.StudyInfoFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @SuppressWarnings("NonAsciiCharacters")
 class StudyInfoServiceTest extends TestConfig {
@@ -66,6 +67,8 @@ class StudyInfoServiceTest extends TestConfig {
     private StudyConventionRepository studyConventionRepository;
     @MockBean
     private GithubApiService githubApiService;
+    @MockBean
+    private GithubApiTokenService githubApiTokenService;
 
     @AfterEach
     void tearDown() {
@@ -88,6 +91,10 @@ class StudyInfoServiceTest extends TestConfig {
         List<StudyCategory> studyCategories = studyCategoryRepository.saveAll(createDefaultPublicStudyCategories(CATEGORY_SIZE));
 
         StudyInfoRegisterRequest studyInfoRegisterRequest = generateStudyInfoRegisterRequestWithCategory(studyCategories);
+
+        when(githubApiTokenService.getToken(any(Long.class))).thenReturn(new GithubApiToken("token", user.getId()));
+        when(githubApiService.createRepository(any(String.class), any(RepositoryInfo.class), any(String.class)))
+                .thenReturn(any());
 
         // when
         StudyInfoRegisterResponse registeredStudy = studyInfoService.registerStudy(studyInfoRegisterRequest, UserInfoResponse.of(user));


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#457 

### Pull Request Type
- [x]  새로운 기능 추가
- [ ]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [x]  테스트 추가, 테스트 리팩토링
- [ ]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist
- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용

사용자별 로그인 시 얻은 Github api Token을 레디스에 저장해 필요할 때 꺼내쓸 수 있도록 구현했습니다.



## 💬 리뷰 요구사항

Github Api 토큰 재발급 로직은 다음 이슈에서 처리하겠습니다~

---

테스트에서 레포지토리 사용한 후 꼭 tearDown에서 지워주세요!
