### PR TITLE
[BE] feat(#459) collaborator 초대 및 수락 자동화 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/common/exception/ExceptionMessage.java
+++ b/backend/src/main/java/com/example/backend/common/exception/ExceptionMessage.java
@@ -84,6 +84,9 @@ public enum ExceptionMessage {
     GITHUB_API_GET_COMMIT_ERROR("커밋을 불러오는데 실패했습니다."),
     GITHUB_API_CREATE_REPOSITORY_ERROR ("GitHub 레포지토리 생성 중 오류가 발생했습니다."),
     GITHUB_API_REPOSITORY_ALREADY_EXISTS("해당 이름의 레포지토리가 이미 존재합니다."),
+    GITHUB_API_ADD_COLLABORATOR_ERROR("GitHub Collaborator 추가가 실패했습니다."),
+    GITHUB_API_ACCEPT_INVITATION_ERROR("초대 수락 중 오류가 발생하였습니다."),
+    GITHUB_API_NO_INVITATIONS_FOUND("초대를 찾을 수 없습니다."),
 
     // GithubApiTokenException
     GITHUB_API_TOKEN_NOT_EXIST("사용자 id에 해당하는 GithubApiToken이 존재하지 않습니다."),

--- a/backend/src/main/java/com/example/backend/study/api/service/github/GithubApiService.java
+++ b/backend/src/main/java/com/example/backend/study/api/service/github/GithubApiService.java
@@ -5,17 +5,13 @@ import com.example.backend.common.exception.github.GithubApiException;
 import com.example.backend.domain.define.study.info.constant.RepositoryInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.kohsuke.github.GHCreateRepositoryBuilder;
-import org.kohsuke.github.GHRepository;
-import org.kohsuke.github.GitHub;
-import org.kohsuke.github.GitHubBuilder;
+import org.kohsuke.github.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
+import java.util.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -66,9 +62,8 @@ public class GithubApiService {
 
             GHCreateRepositoryBuilder repoBuilder = gitHub.createRepository(repoInfo.getName())
                     .description(description)
-                    .private_(false)  // 공개 레포지토리로 설정
-                    .autoInit(true);  // 기본 README 파일 추가
-
+                    .private_(false)
+                    .autoInit(true);
             GHRepository repository = repoBuilder.create();
 
             addWebHook(repository, webhookUrl);
@@ -81,6 +76,58 @@ public class GithubApiService {
             throw new GithubApiException(ExceptionMessage.GITHUB_API_CREATE_REPOSITORY_ERROR);
         }
     }
+
+
+    // 레포지토리에 Collaborator 추가
+    @Transactional
+    public void addCollaborator(String githubApiToken, RepositoryInfo repo, String githubId) {
+        try {
+            GitHub gitHub = connectGithub(githubApiToken);
+            GHRepository repository = getRepository(githubApiToken, repo);
+            GHUser user = gitHub.getUser(githubId);
+            repository.addCollaborators(GHOrganization.Permission.PUSH, user);
+            log.info(">>>> [ {} 사용자를 {} 레포지토리의 Collaborator로 추가했습니다. ] <<<<", githubId, repo.getName());
+        } catch (IOException e) {
+            log.error(">>>> [ {} : {} ] <<<<", ExceptionMessage.GITHUB_API_ADD_COLLABORATOR_ERROR.getText(), e.getMessage());
+            throw new GithubApiException(ExceptionMessage.GITHUB_API_ADD_COLLABORATOR_ERROR);
+        }
+    }
+
+    @Transactional
+    public void acceptInvitation(String githubApiToken) {
+        try {
+            GitHub gitHub = connectGithub(githubApiToken);
+            List<GHInvitation> invitations = new ArrayList<>(gitHub.getMyInvitations());
+
+            if (invitations.isEmpty()) {
+                log.error(">>>> [ {} : {} ] <<<<", ExceptionMessage.GITHUB_API_NO_INVITATIONS_FOUND.getText(), "No invitations found");
+                throw new GithubApiException(ExceptionMessage.GITHUB_API_NO_INVITATIONS_FOUND);
+            } else {
+                // 가장 최근 초대를 찾기 위해 invitations 리스트를 날짜 기준으로 정렬
+                sortInvitations(invitations);
+                GHInvitation latestInvitation = invitations.get(0);
+                log.info(">>>> [ Latest Invitation ID: {} ] <<<<", latestInvitation.getId());
+                latestInvitation.accept();
+                log.info(">>>> [ Invitation accepted. ] <<<<");
+            }
+        } catch (IOException e) {
+            log.error(">>>> [ {} : {} ] <<<<", ExceptionMessage.GITHUB_API_ACCEPT_INVITATION_ERROR.getText(), e.getMessage());
+            throw new GithubApiException(ExceptionMessage.GITHUB_API_ACCEPT_INVITATION_ERROR);
+        }
+    }
+
+    private static void sortInvitations(List<GHInvitation> invitations) {
+        invitations.sort(Comparator.comparing(GithubApiService::getCreatedAtSafe).reversed());
+    }
+
+    private static Date getCreatedAtSafe(GHInvitation invitation) {
+        try {
+            return invitation.getCreatedAt();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
 
     private static void addWebHook(GHRepository repository, String webhookUrl) throws IOException {
         // 웹훅 추가

--- a/backend/src/main/java/com/example/backend/study/api/service/member/StudyMemberService.java
+++ b/backend/src/main/java/com/example/backend/study/api/service/member/StudyMemberService.java
@@ -5,7 +5,9 @@ import com.example.backend.auth.api.controller.auth.response.UserInfoResponse;
 import com.example.backend.common.exception.ExceptionMessage;
 import com.example.backend.common.exception.member.MemberException;
 import com.example.backend.domain.define.account.user.User;
+import com.example.backend.domain.define.study.github.repository.GithubApiTokenRepository;
 import com.example.backend.domain.define.study.info.StudyInfo;
+import com.example.backend.domain.define.study.info.constant.RepositoryInfo;
 import com.example.backend.domain.define.study.info.constant.StudyStatus;
 import com.example.backend.domain.define.study.info.event.ApplyApproveRefuseMemberEvent;
 import com.example.backend.domain.define.study.info.event.ApplyMemberEvent;
@@ -21,6 +23,8 @@ import com.example.backend.study.api.controller.member.request.MessageRequest;
 import com.example.backend.study.api.controller.member.response.StudyMemberApplyListAndCursorIdxResponse;
 import com.example.backend.study.api.controller.member.response.StudyMemberApplyResponse;
 import com.example.backend.study.api.controller.member.response.StudyMembersResponse;
+import com.example.backend.study.api.service.github.GithubApiService;
+import com.example.backend.study.api.service.github.GithubApiTokenService;
 import com.example.backend.study.api.service.info.StudyInfoService;
 import com.example.backend.study.api.service.user.UserService;
 import lombok.RequiredArgsConstructor;
@@ -43,7 +47,8 @@ public class StudyMemberService {
     private final StudyInfoService studyInfoService;
     private final ApplicationEventPublisher eventPublisher;
     private final UserService userService;
-
+    private final GithubApiService githubApiService;
+    private final GithubApiTokenService githubApiTokenService;
     private final static int JOIN_CODE_LENGTH = 10;
     private final static Long MAX_LIMIT = 10L;
 
@@ -268,6 +273,16 @@ public class StudyMemberService {
 
             // 스터디 가입 시 User +5점
             findUser.addUserScore(5);
+
+            // 스터디장 레포지토리에 가입 성공 스터디원 Collaborator 추가
+            RepositoryInfo repoInfo = studyInfo.getRepositoryInfo();
+
+            // 스터디 레포지토리에 초대
+            githubApiService.addCollaborator(githubApiTokenService.getToken(studyInfo.getUserId()).githubApiToken(),
+                    repoInfo, findUser.getGithubId());
+
+            // 스터디원의 초대 수락
+            githubApiService.acceptInvitation(githubApiTokenService.getToken(findUser.getId()).githubApiToken());
 
         } else {
             applyMember.updateStudyMemberStatus(StudyMemberStatus.STUDY_REFUSED);

--- a/backend/src/test/java/com/example/backend/domain/define/study/info/StudyInfoFixture.java
+++ b/backend/src/test/java/com/example/backend/domain/define/study/info/StudyInfoFixture.java
@@ -28,6 +28,11 @@ public class StudyInfoFixture {
                 .status(STUDY_PUBLIC)
                 .currentMember(1)
                 .maximumMember(10)
+                .repositoryInfo(RepositoryInfo.builder()
+                        .owner("user")
+                        .name("name")
+                        .branchName("main")
+                        .build())
                 .build();
     }
 

--- a/backend/src/test/java/com/example/backend/study/api/service/github/GithubApiServiceTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/service/github/GithubApiServiceTest.java
@@ -37,13 +37,23 @@ import static org.junit.jupiter.api.Assertions.*;
 @SuppressWarnings("NonAsciiCharacters")
 class GithubApiServiceTest extends TestConfig {
     private final String REPOSITORY_OWNER = "jusung-c";
+
+    private final String REPOSITORY_COLLABORATOR = "rndudals";
+
     private final String REPOSITORY_NAME = "Github-Api-Test";
+
+    private final String REPOSITORY_DESCRIBE = "[gitudy] Github API test repository description";
+
+    private final String BRANCH_NAME = "main";
 
     @Value("${github.api.webhookURL}")
     private String webhookUrl;
 
     @Value("${github.api.token}")
     private String githubApiToken;
+
+    @Value("${github.api.token-collaborator}")
+    private String githubApiTokenCollaborator;
 
     @Autowired
     private GithubApiService githubApiService;
@@ -83,7 +93,7 @@ class GithubApiServiceTest extends TestConfig {
         RepositoryInfo repo = RepositoryInfo.builder()
                 .owner(REPOSITORY_OWNER)
                 .name(REPOSITORY_NAME)
-                .branchName("main")
+                .branchName(BRANCH_NAME)
                 .build();
 
         // when
@@ -97,24 +107,22 @@ class GithubApiServiceTest extends TestConfig {
     }
 
     // 웹에서 테스트 해야 합니다.
-    //@Test
+    // @Test
     void 깃허브_레포지토리_생성_테스트() throws IOException {
         // given
-        String repoName = "test-repo2";
-        String description = "[gitudy] Github API test repository description";
         RepositoryInfo repoInfo = RepositoryInfo.builder()
-                .owner("rndudals")
-                .name(repoName)
-                .branchName("main")
+                .owner(REPOSITORY_OWNER)
+                .name(REPOSITORY_NAME)
+                .branchName(BRANCH_NAME)
                 .build();
 
         // when
-        GHRepository createdRepository = githubApiService.createRepository(githubApiToken, repoInfo, description);
+        GHRepository createdRepository = githubApiService.createRepository(githubApiToken, repoInfo, REPOSITORY_DESCRIBE);
 
         // then
         assertNotNull(createdRepository);
-        assertEquals(repoName, createdRepository.getName());
-        assertEquals(description, createdRepository.getDescription());
+        assertEquals(REPOSITORY_NAME, createdRepository.getName());
+        assertEquals(REPOSITORY_DESCRIBE, createdRepository.getDescription());
         assertFalse(createdRepository.isPrivate());
 
         // 웹훅 확인
@@ -127,25 +135,48 @@ class GithubApiServiceTest extends TestConfig {
     // @Test
     void 깃허브_레포지토리_생성_중복_예외_테스트() {
         // given
-        String repoName = "test-repo-duplicate";
-        String description = "[gitudy] Github API duplicate test repository description";
         RepositoryInfo repoInfo = RepositoryInfo.builder()
-                .owner("rndudals")
-                .name(repoName)
-                .branchName("main")
+                .owner(REPOSITORY_OWNER)
+                .name(REPOSITORY_NAME)
+                .branchName(BRANCH_NAME)
                 .build();
 
         // 먼저 동일한 이름의 레포지토리를 생성하여 중복 상태를 만듭니다.
-        githubApiService.createRepository(githubApiToken, repoInfo, description);
+        githubApiService.createRepository(githubApiToken, repoInfo, REPOSITORY_DESCRIBE);
 
         // when, then
         GithubApiException exception = assertThrows(GithubApiException.class, () -> {
-            githubApiService.createRepository(githubApiToken, repoInfo, description);
+            githubApiService.createRepository(githubApiToken, repoInfo, REPOSITORY_DESCRIBE);
         });
 
         assertEquals(ExceptionMessage.GITHUB_API_REPOSITORY_ALREADY_EXISTS.getText(), exception.getMessage());
     }
 
+    // 웹에서 테스트 해야 합니다.
+    // @Test
+    public void Collaborator_초대요청_및_수락_성공_테스트() throws Exception {
+        // 실제로 존재하는 GitHub 레포지토리와 사용자 정보로 변경
+        RepositoryInfo repoInfo = new RepositoryInfo(REPOSITORY_OWNER, REPOSITORY_NAME, BRANCH_NAME);
+
+        // 실제 GitHub API를 사용하여 Collaborator 추가
+        githubApiService.addCollaborator(githubApiToken, repoInfo, REPOSITORY_COLLABORATOR);
+
+
+        // 실제 GitHub API를 사용하여 초대 수락
+        githubApiService.acceptInvitation(githubApiTokenCollaborator);
+
+        // 결과 확인은 GitHub 웹사이트에서 직접 확인
+    }
+
+    // 웹에서 테스트 해야 합니다.
+    // @Test
+    void 초대_목록_없음_예외_테스트() {
+        GithubApiException exception = assertThrows(GithubApiException.class, () -> {
+            githubApiService.acceptInvitation(githubApiToken);
+        });
+
+        assertEquals(ExceptionMessage.GITHUB_API_NO_INVITATIONS_FOUND.getText(), exception.getMessage());
+    }
     private boolean isWebhookRegistered(GHRepository repository, String webhookUrl) throws IOException {
         List<GHHook> hooks = repository.getHooks();
         return hooks.stream()

--- a/backend/src/test/java/com/example/backend/study/api/service/member/StudyMemberServiceTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/service/member/StudyMemberServiceTest.java
@@ -12,8 +12,11 @@ import com.example.backend.domain.define.event.FcmFixture;
 import com.example.backend.domain.define.fcm.FcmToken;
 import com.example.backend.domain.define.fcm.listener.*;
 import com.example.backend.domain.define.fcm.repository.FcmTokenRepository;
+import com.example.backend.domain.define.study.github.GithubApiToken;
+import com.example.backend.domain.define.study.github.GithubApiTokenFixture;
 import com.example.backend.domain.define.study.info.StudyInfo;
 import com.example.backend.domain.define.study.info.StudyInfoFixture;
+import com.example.backend.domain.define.study.info.constant.RepositoryInfo;
 import com.example.backend.domain.define.study.info.event.ApplyApproveRefuseMemberEvent;
 import com.example.backend.domain.define.study.info.event.ApplyMemberEvent;
 import com.example.backend.domain.define.study.info.repository.StudyInfoRepository;
@@ -33,6 +36,8 @@ import com.example.backend.domain.define.study.todo.repository.StudyTodoReposito
 import com.example.backend.study.api.controller.member.request.MessageRequest;
 import com.example.backend.study.api.controller.member.response.StudyMemberApplyListAndCursorIdxResponse;
 import com.example.backend.study.api.controller.member.response.StudyMembersResponse;
+import com.example.backend.study.api.service.github.GithubApiService;
+import com.example.backend.study.api.service.github.GithubApiTokenService;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -46,8 +51,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 public class StudyMemberServiceTest extends MockTestConfig {
 
@@ -94,6 +98,11 @@ public class StudyMemberServiceTest extends MockTestConfig {
     @MockBean
     private NotifyLeaderListener notifyLeaderListener;
 
+    @MockBean
+    private GithubApiService githubApiService;
+
+    @MockBean
+    private GithubApiTokenService githubApiTokenService;
 
     public final static Long CursorIdx = null;
     public final static Long Limit = 3L;
@@ -666,6 +675,8 @@ public class StudyMemberServiceTest extends MockTestConfig {
         User leader = UserFixture.generateAuthUser();
         User user1 = UserFixture.generateGoogleUser();
 
+        GithubApiToken githubApiToken = GithubApiTokenFixture.createToken("token", user1.getId());
+
         int beforeUser1Score = user1.getScore();
 
         userRepository.saveAll(List.of(leader, user1));
@@ -677,6 +688,8 @@ public class StudyMemberServiceTest extends MockTestConfig {
 
         StudyMember waitingMember = StudyMemberFixture.createStudyMemberWaiting(user1.getId(), studyInfo.getId());  // 승인 대기중 멤버 생성
         studyMemberRepository.save(waitingMember);
+
+        when(githubApiTokenService.getToken(any(Long.class))).thenReturn(githubApiToken);
 
         // when
         studyMemberService.leaderApproveRefuseMember(studyInfo.getId(), waitingMember.getUserId(), approve);
@@ -691,6 +704,13 @@ public class StudyMemberServiceTest extends MockTestConfig {
 
         // 스터디 가입 시 현재인원 증가
         assertEquals(beforeCurrentMember + 1, studyInfoRepository.findById(studyInfo.getId()).get().getCurrentMember());
+
+        // github api가 작동했는지 확인
+        verify(githubApiService, times(1)).addCollaborator(any(String.class), any(RepositoryInfo.class), any(String.class));
+        verify(githubApiService, times(1)).acceptInvitation(any(String.class));
+
+        // github api가 작동했는지 확인
+        verify(githubApiTokenService, times(2)).getToken((any(Long.class)));
     }
 
     @Test
@@ -703,6 +723,7 @@ public class StudyMemberServiceTest extends MockTestConfig {
         User leader = UserFixture.generateAuthUser();
         User user1 = UserFixture.generateAuthUserPushAlarmY();
 
+        GithubApiToken githubApiToken = GithubApiTokenFixture.createToken("token", user1.getId());
 
         userRepository.saveAll(List.of(leader, user1));
 
@@ -712,11 +733,19 @@ public class StudyMemberServiceTest extends MockTestConfig {
         StudyMember waitingMember = StudyMemberFixture.createStudyMemberWaiting(user1.getId(), studyInfo.getId());  // 승인 대기중 멤버 생성
         studyMemberRepository.save(waitingMember);
 
+        when(githubApiTokenService.getToken(any(Long.class))).thenReturn(githubApiToken);
+
         // when
         studyMemberService.leaderApproveRefuseMember(studyInfo.getId(), waitingMember.getUserId(), approve);
 
         // then
         verify(applyApproveRefuseMemberListener, times(1)).applyApproveRefuseMemberListener(any(ApplyApproveRefuseMemberEvent.class));
+        // github api가 작동했는지 확인
+        verify(githubApiService, times(1)).addCollaborator(any(String.class), any(RepositoryInfo.class), any(String.class));
+        verify(githubApiService, times(1)).acceptInvitation(any(String.class));
+
+        // github api가 작동했는지 확인
+        verify(githubApiTokenService, times(2)).getToken((any(Long.class)));
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

ex) #459 

### Pull Request Type

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [x]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용

스터디 장이 어떤 스터디원의 스터디 가입 신청을 수락했을 때 자동으로 스터디 레포지토리에 스터디원이 collaborator로 추가된다.

 - [x] 스터디 장이 초대를 수락 시, 스터디 레포지토리로 초대하는 로직 자동화 구현 및 테스트
 - [x] 스터디 장이 초대를 수락 시, 스터디원이 초대를 수락하는 것을 자동화 구현 및 테스트

---

### Postman Test

**1. 영민(스터디장) 회원가입**

![영민 회원가입](https://github.com/user-attachments/assets/4f24dbcc-5d04-490a-93fe-84a05e113bb5)

<br>

**2. 스터디 생성**

![스터디 생성](https://github.com/user-attachments/assets/9d91e4db-2e4c-4415-ad8e-027011b2bb17)

<br>

**3. 스터디 생성 결과**

```
studyInfoId = 150
```

![스터디 생성 결과](https://github.com/user-attachments/assets/685906b4-dc76-4f05-973b-6e1f445efafb)

<br>

**4. 주성(스터디원) 회원가입**

![주성 회원가입](https://github.com/user-attachments/assets/bfd4e103-2bfa-4e38-a28f-dc2a1073ecca)

<br>

**5. 스터디 신청** 

```
주성이가 150번 스터디에  가입신청 한다.
```

![id 150 스터디 신청 하기](https://github.com/user-attachments/assets/c9860299-5377-41e9-bd06-89168ef00fd9)

<br>

**6. 스터디 가입 신청 대기**

```
맨 오른쪽에 STUDY_WAITING -> 신청 대기 중라는 뜻
```
![스터디 신청 대기](https://github.com/user-attachments/assets/12ff1529-dbd4-4b36-8bd2-862b9d46b79f)

<br>

**7. 스터디 가입신청 수락**

```
영민이가 주성이의 스터디 가입신청을 수락한다.
```
![스터디 신청 url](https://github.com/user-attachments/assets/912e6891-6a07-4ec3-8977-222b29301444)


<br>

**8. 최종 결과**

![최종 결과](https://github.com/user-attachments/assets/55d75ec1-ad30-4011-b457-23dae4402761)



## 💬 리뷰 요구사항

1. yml 파일 변경되었습니다. (07/27)
2. 테스트 코드 작성이 불가능한 것들은 주석처리해두었습니다.

놓친 점 피드백 부탁드립니다.

