### PR TITLE
[BE] feat(#472): 스터디 랭킹 시스템

### DIFF
--- a/backend/src/main/java/com/example/backend/auth/api/service/rank/RankingService.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/rank/RankingService.java
@@ -1,30 +1,38 @@
 package com.example.backend.auth.api.service.rank;
 
 
+import com.example.backend.auth.api.service.rank.response.StudyRankingResponse;
 import com.example.backend.auth.api.service.rank.response.UserRankingResponse;
 import com.example.backend.domain.define.account.user.User;
 import com.example.backend.domain.define.account.user.repository.UserRepository;
+import com.example.backend.domain.define.study.info.StudyInfo;
+import com.example.backend.domain.define.study.info.repository.StudyInfoRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RankingService {
 
     private final RedisTemplate<String, Object> redisTemplate;
     private final UserRepository userRepository;
+    private final StudyInfoRepository studyInfoRepository;
     public static final String USER_RANKING_KEY = "user_ranking";
+    private static final String STUDY_RANKING_KEY = "study_ranking";
 
     @PostConstruct
     public void init() {
         updateUserRanking();
+        updateStudyRanking();
     }
 
 
@@ -64,4 +72,41 @@ public class RankingService {
         }
     }
 
+    // 마찬가지로 로드 시점에 Cache Warming
+    public void updateStudyRanking() {
+        ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
+        List<StudyInfo> studyInfos = studyInfoRepository.findAll();
+        for (StudyInfo studyInfo : studyInfos) {
+            zSetOps.add(STUDY_RANKING_KEY, studyInfo.getId(), studyInfo.getScore());
+        }
+    }
+
+    // 스터디 점수 업데이트
+    public void updateStudyScore(Long studyInfoId, int score) {
+        ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
+        zSetOps.incrementScore(STUDY_RANKING_KEY, studyInfoId, score);
+    }
+
+    // 스터디 점수를 Redis Sorted Set에 저장
+    public void saveStudyScore(Long studyInfoId, int score) {
+        ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
+        zSetOps.add(STUDY_RANKING_KEY, studyInfoId, score);
+    }
+
+    // 특정 스터디의 랭킹 조회
+    public StudyRankingResponse getStudyRankings(StudyInfo studyInfo) {
+
+        ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
+        Double score = zSetOps.score(STUDY_RANKING_KEY, studyInfo.getScore());
+        if (score == null) {
+            score = (double) studyInfo.getScore();
+            saveStudyScore(studyInfo.getId(), score.intValue());
+        }
+
+        Long ranking = zSetOps.reverseRank(STUDY_RANKING_KEY, studyInfo.getId());
+        if (ranking == null) {
+            return new StudyRankingResponse(score.intValue(), 0L);
+        }
+        return new StudyRankingResponse(score.intValue(), ranking + 1);
+    }
 }

--- a/backend/src/main/java/com/example/backend/auth/api/service/rank/response/StudyRankingResponse.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/rank/response/StudyRankingResponse.java
@@ -1,0 +1,15 @@
+package com.example.backend.auth.api.service.rank.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class StudyRankingResponse {
+
+    private int score;
+
+    private Long ranking;
+}

--- a/backend/src/main/java/com/example/backend/domain/define/rank/StudyRanking.java
+++ b/backend/src/main/java/com/example/backend/domain/define/rank/StudyRanking.java
@@ -1,0 +1,26 @@
+package com.example.backend.domain.define.rank;
+
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@ToString
+@RedisHash(value = "study_ranking")
+@NoArgsConstructor
+@Builder
+public class StudyRanking {
+
+    @Id
+    private Long studyInfoId;
+
+    private int score;
+
+    public StudyRanking(Long studyInfoId, int score) {
+        this.studyInfoId = studyInfoId;
+        this.score = score;
+    }
+}

--- a/backend/src/main/java/com/example/backend/study/api/controller/info/StudyInfoController.java
+++ b/backend/src/main/java/com/example/backend/study/api/controller/info/StudyInfoController.java
@@ -2,6 +2,8 @@ package com.example.backend.study.api.controller.info;
 
 import com.example.backend.auth.api.controller.auth.response.UserInfoResponse;
 import com.example.backend.auth.api.service.auth.AuthService;
+import com.example.backend.auth.api.service.rank.RankingService;
+import com.example.backend.auth.api.service.rank.response.StudyRankingResponse;
 import com.example.backend.domain.define.account.user.User;
 import com.example.backend.study.api.controller.info.request.RepoNameCheckRequest;
 import com.example.backend.study.api.controller.info.request.StudyInfoRegisterRequest;
@@ -10,7 +12,6 @@ import com.example.backend.study.api.controller.info.response.StudyInfoCountResp
 import com.example.backend.study.api.controller.info.response.StudyInfoDetailResponse;
 import com.example.backend.study.api.controller.info.response.StudyInfoListAndCursorIdxResponse;
 import com.example.backend.study.api.controller.info.response.UpdateStudyInfoPageResponse;
-import com.example.backend.study.api.service.github.GithubApiService;
 import com.example.backend.study.api.service.info.StudyInfoService;
 import com.example.backend.study.api.service.member.StudyMemberService;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -32,6 +33,7 @@ public class StudyInfoController {
     private final StudyInfoService studyInfoService;
     private final AuthService authService;
     private final StudyMemberService studyMemberService;
+    private final RankingService rankingService;
 
     @ApiResponse(responseCode = "200", description = "스터디 등록 성공")
     @PostMapping("/")
@@ -120,5 +122,18 @@ public class StudyInfoController {
                                                                     @RequestParam(name = "myStudy", defaultValue = "false") boolean myStudy) {
         UserInfoResponse findUser = authService.findUserInfo(user);
         return ResponseEntity.ok().body(studyInfoService.getStudyInfoCount(findUser.getUserId(), myStudy));
+    }
+
+    @ApiResponse(responseCode = "200", description = "특정스터디 랭킹 요청 성공", content = @Content(schema = @Schema(implementation =
+            StudyRankingResponse.class)))
+    @GetMapping("/rank/{studyInfoId}")
+    public ResponseEntity<StudyRankingResponse> studyRanking(@AuthenticationPrincipal User user,
+                                                             @PathVariable(name = "studyInfoId") Long studyInfoId) {
+
+        authService.findUserInfo(user);
+        // rankingService 단에서 스터디 조회하니 순환 의존성 문제가 발생하여 컨트롤러에서 주입
+        StudyRankingResponse response = rankingService.getStudyRankings(studyInfoService.findStudyInfoByIdOrThrowException(studyInfoId));
+
+        return ResponseEntity.ok().body(response);
     }
 }

--- a/backend/src/test/java/com/example/backend/auth/api/service/rank/RankingServiceTest.java
+++ b/backend/src/test/java/com/example/backend/auth/api/service/rank/RankingServiceTest.java
@@ -2,7 +2,12 @@
 package com.example.backend.auth.api.service.rank;
 
 import com.example.backend.MockTestConfig;
+import com.example.backend.auth.api.service.rank.response.StudyRankingResponse;
 import com.example.backend.domain.define.account.user.repository.UserRepository;
+import com.example.backend.domain.define.study.info.StudyInfo;
+import com.example.backend.domain.define.study.info.StudyInfoFixture;
+import com.example.backend.domain.define.study.info.repository.StudyInfoRepository;
+import com.example.backend.study.api.service.info.StudyInfoService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,26 +26,29 @@ public class RankingServiceTest extends MockTestConfig {
     private RankingService rankingService;
 
     @Autowired
-    private RedisTemplate<String, Object> redisTemplate;
-
-    @Autowired
     private UserRepository userRepository;
 
     @Autowired
     private ZSetOperations<String, Object> zSetOperations;
 
+
+    @Autowired
+    private StudyInfoRepository studyInfoRepository;
+
     private Random random = new Random();
     private static final String USER_RANKING_KEY = "user_ranking";
+    private static final String STUDY_RANKING_KEY = "study_ranking";
 
     @BeforeEach
     void setUp() {
-     //   when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+        //   when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
     }
 
     @AfterEach
     void tearDown() {
         userRepository.deleteAllInBatch();
-      //  redisTemplate.delete(USER_RANKING_KEY);
+       // redisTemplate.delete(USER_RANKING_KEY);
+        //redisTemplate.delete(STUDY_RANKING_KEY);
     }
 
     @Test
@@ -69,8 +77,7 @@ public class RankingServiceTest extends MockTestConfig {
     }
 
 
-   */
-/* @Test
+ @Test
     void 특정_유저_랭킹_조회() {
         User savedUser1 = userRepository.save(generateAuthUser());  // score: 10   4등
         User savedUser2 = userRepository.save(generateAdminUser()); // score: 100  1등
@@ -99,8 +106,66 @@ public class RankingServiceTest extends MockTestConfig {
 
         assertEquals(response1.getRanking(), 4);
         assertEquals(response1.getScore(), 10);
-    }*//*
+    }
 
 
+
+
+
+    @Test
+    void 여러_스터디_점수_저장_테스트() {
+
+        List<Long> studyInfoIds = IntStream.range(1, 100)
+                .mapToObj(i -> (long) i)
+                .toList();
+
+        // 유저 점수 저장 및 확인
+        studyInfoIds.forEach(studyInfoId -> {
+            int score = random.nextInt(1000);  // 0~1000 랜덤 점수
+            rankingService.saveStudyScore(studyInfoId, score);
+            Double storedScore = zSetOperations.score(STUDY_RANKING_KEY, studyInfoId);
+            assertEquals(score, storedScore.intValue());
+        });
+
+    }
+
+    @Test
+    void 특정_스터디_점수_업데이트_테스트() {
+
+        Long studyInfoId = 96L;
+
+        rankingService.updateStudyScore(studyInfoId, 13);
+    }
+
+    @Test
+    void 특정_스터디_랭킹_조회() {
+
+        StudyInfo studyInfo1 = studyInfoRepository.save(StudyInfoFixture.createPublicStudyInfoScore(1L, 530));
+        StudyInfo studyInfo2 = studyInfoRepository.save(StudyInfoFixture.createPublicStudyInfoScore(2L, 100));
+        StudyInfo studyInfo3 = studyInfoRepository.save(StudyInfoFixture.createPublicStudyInfoScore(3L, 40));
+        StudyInfo studyInfo4 = studyInfoRepository.save(StudyInfoFixture.createPublicStudyInfoScore(4L, 1200));
+
+        rankingService.saveStudyScore(studyInfo1.getId(), studyInfo1.getScore());
+        rankingService.saveStudyScore(studyInfo2.getId(), studyInfo2.getScore());
+
+        StudyRankingResponse response1 = rankingService.getStudyRankings(studyInfo1);
+        StudyRankingResponse response2 = rankingService.getStudyRankings(studyInfo2);
+        // 3과4는 redis에 점수가 null로 저장되어있을때 잘 가져오는지 확인
+        StudyRankingResponse response3 = rankingService.getStudyRankings(studyInfo3);
+        StudyRankingResponse response4 = rankingService.getStudyRankings(studyInfo4);
+
+        //then
+        assertEquals(response4.getRanking(), 1);
+        assertEquals(response4.getScore(), 1200);
+
+        assertEquals(response1.getRanking(), 2);
+        assertEquals(response1.getScore(), 530);
+
+        assertEquals(response2.getRanking(), 3);
+        assertEquals(response2.getScore(), 100);
+
+        assertEquals(response3.getRanking(), 4);
+        assertEquals(response3.getScore(), 40);
+    }
 }
 */

--- a/backend/src/test/java/com/example/backend/domain/define/study/info/StudyInfoFixture.java
+++ b/backend/src/test/java/com/example/backend/domain/define/study/info/StudyInfoFixture.java
@@ -339,4 +339,22 @@ public class StudyInfoFixture {
         }
         return studyInfos;
     }
+
+
+    // 스코어와 저장 테스트
+    public static StudyInfo createPublicStudyInfoScore(Long userId, int score) {
+        return StudyInfo.builder()
+                .userId(userId)
+                .topic("토픽")
+                .status(STUDY_PUBLIC)
+                .currentMember(1)
+                .maximumMember(10)
+                .score(score)
+                .repositoryInfo(RepositoryInfo.builder()
+                        .owner("user")
+                        .name("name")
+                        .branchName("main")
+                        .build())
+                .build();
+    }
 }

--- a/backend/src/test/java/com/example/backend/study/api/controller/info/StudyInfoControllerTest.java
+++ b/backend/src/test/java/com/example/backend/study/api/controller/info/StudyInfoControllerTest.java
@@ -4,6 +4,8 @@ import com.example.backend.MockTestConfig;
 import com.example.backend.auth.api.controller.auth.response.UserInfoResponse;
 import com.example.backend.auth.api.service.auth.AuthService;
 import com.example.backend.auth.api.service.jwt.JwtService;
+import com.example.backend.auth.api.service.rank.RankingService;
+import com.example.backend.auth.api.service.rank.response.StudyRankingResponse;
 import com.example.backend.common.exception.ExceptionMessage;
 import com.example.backend.common.utils.TokenUtil;
 import com.example.backend.domain.define.account.user.User;
@@ -21,7 +23,6 @@ import com.example.backend.study.api.controller.info.response.StudyInfoRegisterR
 import com.example.backend.study.api.controller.info.response.UpdateStudyInfoPageResponse;
 import com.example.backend.study.api.service.info.StudyInfoService;
 import com.example.backend.study.api.service.member.StudyMemberService;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.AfterEach;
@@ -75,6 +76,9 @@ class StudyInfoControllerTest extends MockTestConfig {
     private StudyCategoryRepository studyCategoryRepository;
     @MockBean
     private StudyMemberService studyMemberService;
+
+    @MockBean
+    private RankingService rankingService;
 
     @AfterEach
     void tearDown() {
@@ -616,6 +620,28 @@ class StudyInfoControllerTest extends MockTestConfig {
                 .andExpect(jsonPath("$.message").value(containsString("name: " + ExceptionMessage.STUDY_REPOSITORY_NAME_INVALID_CHARS.getText())))
                 .andExpect(jsonPath("$.message").value(containsString("name: " + ExceptionMessage.STUDY_REPOSITORY_NAME_CONSECUTIVE_SPECIAL_CHARS.getText())))
                 .andExpect(jsonPath("$.message").value(containsString("name: " + ExceptionMessage.STUDY_REPOSITORY_NAME_ENDS_WITH_SPECIAL_CHAR.getText())))
+                .andDo(print());
+    }
+
+
+    @Test
+    void 특정_스터디_활동점수_랭킹_테스트() throws Exception {
+        //given
+        User savedUser = userRepository.save(generateAuthUser());
+
+        StudyInfo studyInfo = studyInfoRepository.save(createPublicStudyInfoScore(savedUser.getId(), 10));
+
+        Map<String, String> map = TokenUtil.createTokenMap(savedUser);
+        String accessToken = jwtService.generateAccessToken(map, savedUser);
+
+        when(rankingService.getStudyRankings(studyInfo)).thenReturn(any(StudyRankingResponse.class));
+
+        // when
+        mockMvc.perform(get("/study/rank/" + studyInfo.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(AUTHORIZATION, createAuthorizationHeader(accessToken)))
+
+                .andExpect(status().isOk())
                 .andDo(print());
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#472 

### Pull Request Type

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [x]  테스트 추가, 테스트 리팩토링
- [ ]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용

유저 랭킹 시스템과 마찬가지로 실제 객체사용해서 실제로 저장하는지, 정렬되는지, 랭킹반환잘 되는지 확인해보고 모의객체 테스트는 따로 구현하지 않았슴다,, 아래사진이 실제객체사용한 테스트 결과입니다.

1. 스터디 점수 저장 테스트
![스터디 점수 저장 테스트1](https://github.com/user-attachments/assets/3e524b1a-0285-4841-978f-21d08b74104a)
![스터디 점수 저장 테스트2](https://github.com/user-attachments/assets/d73d4209-c3fd-4476-bff9-da4243b5e8fd)

2. 특정스터디 점수 업데이트
![특정 스터디 점수 업데이트 테스트](https://github.com/user-attachments/assets/d1aa885d-fdbd-4792-9208-f2afa1cd866d)

3. 특정스터디 랭킹 조회 (null일 경우도 테스트)
![특정 스터디 랭킹 조회 (null일경우도 테스트)](https://github.com/user-attachments/assets/d1b7c86d-7d8d-4fde-a149-16bb71fa51b0)

## 💬 리뷰 요구사항

원래는 스터디조회에 rank 필드를 넣어주려 시도해보았지만 queryDSL도 그렇고 대공사가 될것 같아서 스터디랭킹은 호출하는 api를 따로 구현했습니다!

