### PR TITLE
[BE] refactor(#508): 알림 전체 목록 api 필드 추가

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/define/study/info/event/ApplyApproveRefuseMemberEvent.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/info/event/ApplyApproveRefuseMemberEvent.java
@@ -14,6 +14,8 @@ public class ApplyApproveRefuseMemberEvent {
 
     private boolean isPushAlarmYn; // fcm 알림 여부
 
+    private Long studyInfoId;
+
     private boolean approve;   // 승인 여부
 
     private Long applyUserId;  // 가입신청자 Id

--- a/backend/src/main/java/com/example/backend/domain/define/study/member/event/NotifyLeaderEvent.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/member/event/NotifyLeaderEvent.java
@@ -16,6 +16,8 @@ public class NotifyLeaderEvent {
 
     private Long notifyUserId;   // 알림받는 UserId
 
+    private Long studyInfoId;
+
     private String studyTopic;   // 알림보내는 스터디
 
     private String studyMemberName;   // 알림보내는 멤버 이름

--- a/backend/src/main/java/com/example/backend/domain/define/study/member/event/NotifyMemberEvent.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/member/event/NotifyMemberEvent.java
@@ -14,6 +14,8 @@ public class NotifyMemberEvent {
 
     private boolean isPushAlarmYn; // fcm 알림여부 확인
 
+    private Long studyInfoId;
+
     private Long notifyUserId;   // 알림받는 UserId
 
     private String studyTopic;   // 알림보내는 스터디

--- a/backend/src/main/java/com/example/backend/domain/define/study/member/event/ResignMemberEvent.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/member/event/ResignMemberEvent.java
@@ -13,6 +13,8 @@ public class ResignMemberEvent {
 
     private boolean isPushAlarmYn;  // fcm 알림여부
 
+    private Long studyInfoId;
+
     private Long resignMemberId;  // 강퇴당한 멤버
 
     private String studyInfoTopic; // 강퇴당한 스터디

--- a/backend/src/main/java/com/example/backend/domain/define/study/member/event/WithdrawalMemberEvent.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/member/event/WithdrawalMemberEvent.java
@@ -13,6 +13,8 @@ public class WithdrawalMemberEvent {
 
     private boolean isPushAlarmYn;  // fcm 알림 여부
 
+    private Long studyInfoId;
+
     private Long studyLeaderId;  // 스터디장 id
 
     private String withdrawalMemberName; // 탈퇴한 멤버 이름

--- a/backend/src/main/java/com/example/backend/domain/define/study/todo/event/TodoRegisterMemberEvent.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/todo/event/TodoRegisterMemberEvent.java
@@ -18,5 +18,7 @@ public class TodoRegisterMemberEvent {
 
     private List<Long> pushAlarmYMemberIds;  // isPushAlarmY인 멤버
 
+    private Long studyInfoId;
+
     private String studyTopic; // 스터디 Topic
 }

--- a/backend/src/main/java/com/example/backend/domain/define/study/todo/event/TodoUpdateMemberEvent.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/todo/event/TodoUpdateMemberEvent.java
@@ -17,6 +17,8 @@ public class TodoUpdateMemberEvent {
 
     private List<Long> pushAlarmYMemberIds;  // isPushAlarmY인 멤버
 
+    private Long studyInfoId;
+
     private String studyTopic; // 스터디 Topic
 
     private String todoTitle; // 변경 전 투두 이름

--- a/backend/src/main/java/com/example/backend/study/api/event/service/NoticeService.java
+++ b/backend/src/main/java/com/example/backend/study/api/event/service/NoticeService.java
@@ -98,8 +98,9 @@ public class NoticeService {
     public void ResignMemberNotice(ResignMemberEvent event) {
         Notice notice = Notice.builder()
                 .userId(event.getResignMemberId())
-                .title("알림 - 추후 변경예정")
-                .message("[" + event.getStudyInfoTopic() + "] 스터디에서 강퇴 되었습니다.")
+                .studyInfoId(event.getStudyInfoId())
+                .title("[" + event.getStudyInfoTopic() + "] 스터디 알림")
+                .message("[" + event.getStudyInfoTopic() + "]에서 강퇴 되었습니다.")
                 .localDateTime(LocalDateTime.now())
                 .build();
         noticeRepository.save(notice);
@@ -110,7 +111,8 @@ public class NoticeService {
     public void WithdrawalMemberNotice(WithdrawalMemberEvent event) {
         Notice notice = Notice.builder()
                 .userId(event.getStudyLeaderId())
-                .title("[" + event.getStudyInfoTopic() + "] 탈퇴")
+                .studyInfoId(event.getStudyInfoId())
+                .title("[" + event.getStudyInfoTopic() + "] 스터디 알림")
                 .message(event.getWithdrawalMemberName() + "님이 탈퇴 하셨습니다.")
                 .localDateTime(LocalDateTime.now())
                 .build();
@@ -135,6 +137,7 @@ public class NoticeService {
         }
         notice = Notice.builder()
                 .userId(event.getApplyUserId())
+                .studyInfoId(event.getStudyInfoId())
                 .title(title)
                 .message(message)
                 .localDateTime(LocalDateTime.now())
@@ -150,6 +153,7 @@ public class NoticeService {
         for (Long memberId : event.getActivesMemberIds()) {
             Notice notice = Notice.builder()
                     .userId(memberId)
+                    .studyInfoId(event.getStudyInfoId())
                     .title("[" + event.getStudyTopic() + "] TO-DO 업데이트")
                     .message("새로운 TO-DO가 업데이트 되었습니다. 지금 확인해보세요!")
                     .localDateTime(LocalDateTime.now())
@@ -166,6 +170,7 @@ public class NoticeService {
         for (Long memberId : event.getActivesMemberIds()) {
             Notice notice = Notice.builder()
                     .userId(memberId)
+                    .studyInfoId(event.getStudyInfoId())
                     .title("[" + event.getStudyTopic() + "] TO-DO 업데이트")
                     .message("TO-DO가 업데이트 되었습니다. 지금 확인해보세요!")
                     .localDateTime(LocalDateTime.now())
@@ -180,6 +185,7 @@ public class NoticeService {
 
         Notice notice = Notice.builder()
                 .userId(event.getNotifyUserId())
+                .studyInfoId(event.getStudyInfoId())
                 .title("[" + event.getStudyTopic() + "] 스터디 에서 알림")
                 .message(event.getMessage())
                 .localDateTime(LocalDateTime.now())
@@ -193,6 +199,7 @@ public class NoticeService {
 
         Notice notice = Notice.builder()
                 .userId(event.getNotifyUserId())
+                .studyInfoId(event.getStudyInfoId())
                 .title("[" + event.getStudyTopic() + "] 스터디 에서 알림")
                 .message(event.getStudyMemberName() + "님의 알림" + event.getMessage())
                 .localDateTime(LocalDateTime.now())

--- a/backend/src/main/java/com/example/backend/study/api/service/member/StudyMemberService.java
+++ b/backend/src/main/java/com/example/backend/study/api/service/member/StudyMemberService.java
@@ -120,6 +120,7 @@ public class StudyMemberService {
         // 알림 비동기처리
         eventPublisher.publishEvent(ResignMemberEvent.builder()
                 .isPushAlarmYn(resignUser.isPushAlarmYn())
+                .studyInfoId(studyInfo.getId())
                 .resignMemberId(resignUserId)
                 .studyInfoTopic(studyInfo.getTopic())
                 .build());
@@ -151,6 +152,7 @@ public class StudyMemberService {
         // 알림 비동기처리
         eventPublisher.publishEvent(WithdrawalMemberEvent.builder()
                 .isPushAlarmYn(studyLeader.isPushAlarmYn())
+                .studyInfoId(studyInfo.getId())
                 .studyLeaderId(studyInfo.getUserId())
                 .withdrawalMemberName(user.getName())
                 .studyInfoTopic(studyInfo.getTopic())
@@ -296,6 +298,7 @@ public class StudyMemberService {
         eventPublisher.publishEvent(ApplyApproveRefuseMemberEvent.builder()
                 .isPushAlarmYn(applyUser.isPushAlarmYn())
                 .approve(approve)
+                .studyInfoId(studyInfo.getId())
                 .applyUserId(applyUserId)
                 .studyTopic(studyInfo.getTopic())
                 .name(applyUser.getName())
@@ -343,6 +346,7 @@ public class StudyMemberService {
         eventPublisher.publishEvent(NotifyMemberEvent.builder()
                 .isPushAlarmYn(notifyUser.isPushAlarmYn())
                 .notifyUserId(notifyUserId)
+                .studyInfoId(studyInfo.getId())
                 .studyTopic(studyInfo.getTopic())
                 .message(messageRequest.getMessage())
                 .build());
@@ -363,6 +367,7 @@ public class StudyMemberService {
         eventPublisher.publishEvent(NotifyLeaderEvent.builder()
                 .isPushAlarmYn(notifyUser.isPushAlarmYn())
                 .notifyUserId(studyInfo.getUserId())
+                .studyInfoId(studyInfo.getId())
                 .studyMemberName(userInfo.getName())
                 .message(messageRequest.getMessage())
                 .build());


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#508 

### Pull Request Type

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용

프론트 요청사항에 따라 알림 전체를 불러오는 api에 studyInfoId를 반환하도록 추가한다.

GET(/notice)
: 여기에서 모든 알림이 study_info_id 반환하도록 하는 필드 필요 → 알림 클릭했을 때, 해당 스터디로 이동하도록 하는 기능 구현하기 위해 필요함

## 💬 리뷰 요구사항


