### PR TITLE
[BE] refactor(#510) 스터디 가입 신청 로직 관련 이슈 수정

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/define/study/info/repository/StudyInfoRepositoryImpl.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/info/repository/StudyInfoRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.example.backend.domain.define.study.info.repository;
 
 import com.example.backend.domain.define.study.info.StudyInfo;
+import com.example.backend.domain.define.study.member.constant.StudyMemberStatus;
 import com.example.backend.domain.define.study.info.constant.StudyStatus;
 import com.example.backend.study.api.controller.info.response.StudyInfoListResponse;
 import com.querydsl.core.types.OrderSpecifier;
@@ -71,7 +72,8 @@ public class StudyInfoRepositoryImpl implements StudyInfoRepositoryCustom {
         // myStudy에 따라서 동적으로 추가 또는 제거
         if (myStudy) {
             query.innerJoin(studyMember).on(studyMember.studyInfoId.eq(studyInfo.id))
-                    .where(studyMember.userId.eq(userId));
+                    .where(studyMember.userId.eq(userId)
+                            .and(studyMember.status.eq(StudyMemberStatus.STUDY_ACTIVE)));
         }
         query.orderBy(orderSpecifier, idOrder); // 다중 정렬 조건 적용
 

--- a/backend/src/main/java/com/example/backend/study/api/controller/info/response/StudyInfoDetailResponse.java
+++ b/backend/src/main/java/com/example/backend/study/api/controller/info/response/StudyInfoDetailResponse.java
@@ -50,7 +50,9 @@ public class StudyInfoDetailResponse {
 
     private Boolean isLeader;                       // 스터디 리더인지
 
-    public static StudyInfoDetailResponse of(StudyInfo studyInfo, List<String> categoryNames, Long userId) {
+    private Boolean isWaiting;
+
+    public static StudyInfoDetailResponse of(StudyInfo studyInfo, List<String> categoryNames, Long userId, Boolean isWaiting) {
         return StudyInfoDetailResponse.builder()
                 .userId(studyInfo.getUserId())
                 .topic(studyInfo.getTopic())
@@ -67,6 +69,7 @@ public class StudyInfoDetailResponse {
                 .repositoryInfo(studyInfo.getRepositoryInfo())
                 .categoryNames(categoryNames)
                 .isLeader(studyInfo.getUserId().equals(userId))
+                .isWaiting(isWaiting)
                 .build();
     }
 }

--- a/backend/src/main/java/com/example/backend/study/api/service/info/StudyInfoService.java
+++ b/backend/src/main/java/com/example/backend/study/api/service/info/StudyInfoService.java
@@ -170,7 +170,7 @@ public class StudyInfoService {
         StudyInfo studyInfo = findStudyInfoByIdOrThrowException(studyInfoId);
 
         List<String> categoryNames = studyCategoryRepository.findCategoryNameListByStudyInfoJoinCategoryMapping(studyInfoId);
-        return getStudyInfoDetailResponse(studyInfo, categoryNames, userId);
+        return getStudyInfoDetailResponse(studyInfo, categoryNames, userId, studyMemberRepository.existsStudyMemberByUserIdAndStudyInfoId(userId, studyInfoId));
     }
 
     // 마이/전체스터디 개수 조회
@@ -181,8 +181,8 @@ public class StudyInfoService {
     }
 
     // StudyInfoDetailResponse를 생성해주는 함수
-    private static StudyInfoDetailResponse getStudyInfoDetailResponse(StudyInfo studyInfo, List<String> categoryNames, Long userId) {
-        return StudyInfoDetailResponse.of(studyInfo, categoryNames, userId);
+    private static StudyInfoDetailResponse getStudyInfoDetailResponse(StudyInfo studyInfo, List<String> categoryNames, Long userId, boolean isWaiting) {
+        return StudyInfoDetailResponse.of(studyInfo, categoryNames, userId, isWaiting);
     }
 
     // Map<STUDY_INFO_ID, List<STUDY_CATEGORY_NAME>> 생성해주는 함수


### PR DESCRIPTION
## #️⃣ 연관된 이슈

ex) #510

### Pull Request Type

어떤 변경 사항이 있나요?

- [ ]  새로운 기능 추가
- [x]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용

1. 스터디 가입 신청했을 때, 팀장이 승인 전인데 사용자 마이스터디에 등록되어있음
>팀장 승인 전 까지는 마이스터디에서 조회하지 못하도록 처리


<br>

2. GET:/study/{studyInfoId}에 현재 스터디에 가입 신청되어있는지 여부 확인하는 필드 추가
>프론트 단에서 권한 설정을 위해 필요

```
{
  "id": 0,
  "user_id": 0,
  "topic": "string",
  "score": 0,
  "info": "string",
  "maximum_member": 0,
  "current_member": 0,
  "last_commit_day": "2024-08-11",
  "profile_image_url": "string",
  "period_type": "STUDY_PERIOD_EVERYDAY",
  "status": "STUDY_PUBLIC",
  "created_date_time": "2024-08-11T01:14:43.530Z",
  "modified_date_time": "2024-08-11T01:14:43.530Z",
  "category_names": [
    "string"
  ],
  "repository_info": {
    "owner": "string",
    "name": "string",
    "branch_name": "string"
  },
  "is_leader": true,
  "is_waiting": true
}
```

<br>

3. GET:/study/{studyInfoId}에 repository_info 수정 -> 스터디 레포지토리 주소 반환하는 필드로 수정
>repository_info에 있는 owner, name으로 조합해서 프론트 단에서 사용하면 될듯 합니다.

```
https://github.com/{owner}/{name}
```

## 💬 리뷰 요구사항

놓친 거 말씀해주세요~!

