### PR TITLE
[BE] refactor(#541): 탈퇴한 회원 재가입 가능하도록 수정

### DIFF
--- a/backend/src/main/java/com/example/backend/auth/api/controller/auth/AuthController.java
+++ b/backend/src/main/java/com/example/backend/auth/api/controller/auth/AuthController.java
@@ -183,4 +183,13 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
+    @ApiResponse(responseCode = "200", description = "탈퇴한 회원 재가입 성공")
+    @PostMapping("/re-register")
+    public ResponseEntity<Void> reRegisterWithdrawnUser(@AuthenticationPrincipal User user) {
+
+        authService.reRegisterWithdrawnUser(user);
+
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/backend/src/main/java/com/example/backend/auth/api/controller/auth/AuthController.java
+++ b/backend/src/main/java/com/example/backend/auth/api/controller/auth/AuthController.java
@@ -183,13 +183,13 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
-    @ApiResponse(responseCode = "200", description = "탈퇴한 회원 재가입 성공")
+    @ApiResponse(responseCode = "200", description = "탈퇴한 회원 계정 복구 성공")
     @PostMapping("/re-register")
-    public ResponseEntity<Void> reRegisterWithdrawnUser(@AuthenticationPrincipal User user) {
+    public ResponseEntity<AuthLoginResponse> reRegisterWithdrawnUser(@AuthenticationPrincipal User user) {
 
-        authService.reRegisterWithdrawnUser(user);
+        AuthLoginResponse response = authService.reRegisterWithdrawnUser(user);
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok().body(response);
     }
 
 }

--- a/backend/src/main/java/com/example/backend/auth/api/service/auth/AuthService.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/auth/AuthService.java
@@ -317,7 +317,7 @@ public class AuthService {
     }
 
     @Transactional
-    public void reRegisterWithdrawnUser(User contextUser) {
+    public AuthLoginResponse reRegisterWithdrawnUser(User contextUser) {
         User findUser = userRepository.findByPlatformIdAndPlatformType(contextUser.getPlatformId(), contextUser.getPlatformType())
                 .orElseThrow(() -> {
                     log.error(">>>> User not found for platformId {} and platformType {} <<<<", contextUser.getPlatformId(), contextUser.getPlatformType());
@@ -326,5 +326,14 @@ public class AuthService {
 
         findUser.reRegister();
         log.info("User re-Register Success: {}", findUser.getGithubId());
+
+        // JWT Access Token, Refresh Token 재발급
+        JwtToken tokens = generateJwtToken(findUser);
+
+        return AuthLoginResponse.builder()
+                .accessToken(tokens.getAccessToken())
+                .refreshToken(tokens.getRefreshToken())
+                .role(findUser.getRole())
+                .build();
     }
 }

--- a/backend/src/main/java/com/example/backend/auth/config/security/SecurityConfig.java
+++ b/backend/src/main/java/com/example/backend/auth/config/security/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
                                 .requestMatchers("/webhook/**").hasAnyAuthority("ADMIN")
                                 // register
                                 .requestMatchers("/auth/register").hasAnyAuthority("UNAUTH", "WITHDRAW")
+                                .requestMatchers("/auth/re-register").hasAnyAuthority("WITHDRAW")
                                 // reissue
                                 .requestMatchers("/auth/reissue").permitAll()
                                 // update

--- a/backend/src/main/java/com/example/backend/auth/config/security/SecurityConfig.java
+++ b/backend/src/main/java/com/example/backend/auth/config/security/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
                                 // Webhook Area
                                 .requestMatchers("/webhook/**").hasAnyAuthority("ADMIN")
                                 // register
-                                .requestMatchers("/auth/register").hasAnyAuthority("UNAUTH")
+                                .requestMatchers("/auth/register").hasAnyAuthority("UNAUTH", "WITHDRAW")
                                 // reissue
                                 .requestMatchers("/auth/reissue").permitAll()
                                 // update

--- a/backend/src/main/java/com/example/backend/common/exception/ExceptionMessage.java
+++ b/backend/src/main/java/com/example/backend/common/exception/ExceptionMessage.java
@@ -37,6 +37,7 @@ public enum ExceptionMessage {
     AUTH_DUPLICATE_UNAUTH_REGISTER("중복된 회원가입 요청입니다."),
     AUTH_NOT_FOUND("계정 정보를 찾을 수 없습니다."),
     AUTH_DELETE_FAIL("계정 삭제에 실패했습니다."),
+    AUTH_WITHDRAWN_USER("탈퇴한 사용자입니다. 다시 가입하려면 추가적인 절차가 필요합니다."),
 
     // UserException
     USER_NOT_FOUND("데이터베이스에서 사용자를 찾을 수 없습니다."),

--- a/backend/src/main/java/com/example/backend/domain/define/account/user/User.java
+++ b/backend/src/main/java/com/example/backend/domain/define/account/user/User.java
@@ -111,6 +111,10 @@ public class User extends BaseEntity implements UserDetails {
         this.role = UserRole.WITHDRAW;
     }
 
+    public void reRegister() {
+        this.role = UserRole.USER;
+    }
+
     // Score 업데이트 메서드
     public void addUserScore(int score) {
         this.score = Math.max(0, this.score + score);

--- a/backend/src/test/java/com/example/backend/auth/config/fixture/UserFixture.java
+++ b/backend/src/test/java/com/example/backend/auth/config/fixture/UserFixture.java
@@ -34,6 +34,18 @@ public class UserFixture {
                 .build();
     }
 
+    public static User generateWithdrawUser() {
+        return User.builder()
+                .platformId("withdraw")
+                .platformType(GITHUB)
+                .role(WITHDRAW)
+                .name("withdraw")
+                .githubId("withdraw")
+                .profileImageUrl("withdraw")
+                .score(10)
+                .build();
+    }
+
     public static User generateAuthUserByGithubId(String githubId) {
         return User.builder()
                 .platformId("1")


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#541 

### Pull Request Type
- [x]  새로운 기능 추가
- [x]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [x]  테스트 추가, 테스트 리팩토링
- [ ]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist
- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용

현재 회원 탈퇴를 할 경우 데이터를 삭제하는 것이 아닌 상태만 탈퇴 상태로 바꿔주고 있습니다.

따라서 탈퇴한 계정의 깃허브 아이디로 다시 회원가입을 시도할 경우 깃허브 OAuth 로그인으로 내려받는 platformId 값이 동일해서 기존 탈퇴한 계정 정보와 충돌됩니다. 

생각한 방법은 2가지입니다.

1. 회원 탈퇴할 경우 회원 데이터 완전히 삭제
2. 회원 탈퇴한 후 재가입이 아닌 계정 복구 로직

---

### 계정 복구 로직
회원 정보를 삭제하긴 아쉬워서 일단 계정 복구 로직을 적용해보았습니다.

계정 복구 흐름은 다음과 같습니다.

1. 탈퇴한 계정의 깃허브 아이디로 로그인
2. 회원가입 시도
3. 탈퇴한 계정임을 알리는 예외 발생
4. 프론트에서 계정 복구 여부 확인 창 띄워주기
5. 확인 누르면 탈퇴 계정의 상태를 다시 회원 상태로 복구해 계정 복구
6. 메인 화면으로 보내기 or 계정 수정 페이지로 리다이렉트

---

계정 복구 로직을 사용할 경우 요구사항이었던 "닉네임 중복확인 시, 탈퇴한 회원의 닉네임이 포함되지 않게 해주세요" 를 해결할 수 없었습니다.
(복구할 경우 이전 닉네임으로 복구되기 때문에)

회의 때 얘기해봐요~


<br/>
<br/>
<br/>

