### PR TITLE
[BE] refactor(#542) webhook 처리 로직 수정

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/define/study/commit/StudyCommit.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/commit/StudyCommit.java
@@ -35,7 +35,7 @@ public class StudyCommit extends BaseEntity {
     @Column(name = "USER_ID", nullable = false)
     private Long userId;                        // 사용자 정보
 
-    @Column(name = "COMMIT_SHA", nullable = false, unique = true)
+    @Column(name = "COMMIT_SHA", nullable = false)
     private String commitSHA;                   // 커밋의 식별자 SHA 값
 
     @Column(name = "MESSAGE", nullable = false)

--- a/backend/src/main/java/com/example/backend/domain/define/study/commit/repository/StudyCommitRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/commit/repository/StudyCommitRepository.java
@@ -14,7 +14,5 @@ public interface StudyCommitRepository extends JpaRepository<StudyCommit, Long>,
 
     List<StudyCommit> findStudyCommitListByStudyInfoIdAndStatus(Long studyInfoId, CommitStatus status);
 
-    boolean existsByCommitSHA(String commitSha);
-
-    Optional<StudyCommit> findByStudyTodoIdAndUserId(Long todoId, Long userId);
+    List<StudyCommit> findByStudyTodoIdAndUserId(Long todoId, Long userId);
 }

--- a/backend/src/main/java/com/example/backend/webhook/api/controller/request/CommitPayload.java
+++ b/backend/src/main/java/com/example/backend/webhook/api/controller/request/CommitPayload.java
@@ -1,0 +1,16 @@
+package com.example.backend.webhook.api.controller.request;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+public record CommitPayload(
+        String commitId,             // 커밋 ID
+        String message,              // 커밋 메시지
+        String username,             // 커밋한 사용자의 깃허브 ID
+        List<String> commitAdded,    // 추가된 파일 리스트
+        List<String> commitModified, // 수정된 파일 리스트
+        LocalDate commitDate         // 커밋 날짜
+) {}

--- a/backend/src/main/java/com/example/backend/webhook/api/controller/request/WebhookPayload.java
+++ b/backend/src/main/java/com/example/backend/webhook/api/controller/request/WebhookPayload.java
@@ -4,15 +4,11 @@ import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Builder
 public record WebhookPayload(
-        String commitId,
-        String message,
-        String username,
         @Pattern(regexp = "^.+/.+$", message = "레포지토리명은 'username/repository' 형태이여야 합니다.")
         String repositoryFullName,
-        String folderName,
-        LocalDate commitDate
+        List<CommitPayload> commits
 ) {}
-

--- a/backend/src/main/java/com/example/backend/webhook/api/service/WebhookService.java
+++ b/backend/src/main/java/com/example/backend/webhook/api/service/WebhookService.java
@@ -15,16 +15,23 @@ import com.example.backend.domain.define.study.info.StudyInfo;
 import com.example.backend.domain.define.study.info.repository.StudyInfoRepository;
 import com.example.backend.domain.define.study.member.repository.StudyMemberRepository;
 import com.example.backend.domain.define.study.todo.info.StudyTodo;
+import com.example.backend.domain.define.study.todo.mapping.StudyTodoMapping;
 import com.example.backend.domain.define.study.todo.mapping.constant.StudyTodoStatus;
 import com.example.backend.domain.define.study.todo.mapping.repository.StudyTodoMappingRepository;
 import com.example.backend.domain.define.study.todo.repository.StudyTodoRepository;
 import com.example.backend.study.api.service.user.UserService;
+import com.example.backend.webhook.api.controller.request.CommitPayload;
 import com.example.backend.webhook.api.controller.request.WebhookPayload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static com.example.backend.domain.define.study.todo.mapping.constant.StudyTodoStatus.*;
 
 @Slf4j
 @Service
@@ -46,32 +53,48 @@ public class WebhookService {
         // 스터디 특정
         StudyInfo study = getStudyByPayLoad(payload.repositoryFullName());
 
-        // 투두 특정
-        StudyTodo todo = getTodoByPayLoad(payload.folderName());
+        for (CommitPayload commit : payload.commits()) {
+            // 추가/수정 커밋리스트에서 폴더 이름 추출
+            Set<String> folderNames = extractFolderNames(commit.commitAdded(), commit.commitModified());
 
-        // 사용자 특정
-        User user = getUserByPayLoad(payload.username());
+            for (String folderName : folderNames) {
+                // 투두 특정
+                StudyTodo todo = getTodoByPayLoad(folderName);
 
-        // 권한 검증
-        if (!studyMemberRepository.existsStudyMemberByUserIdAndStudyInfoId(user.getId(), study.getId())) {
-            log.warn(">>>> Github ID: {} {} <<<<", payload.username(), ExceptionMessage.STUDY_NOT_ACTIVE_MEMBER.getText());
-            throw new MemberException(ExceptionMessage.STUDY_NOT_ACTIVE_MEMBER);
+                // 사용자 특정
+                User user = getUserByPayLoad(commit.username());
+
+                // 권한 검증
+                if (!studyMemberRepository.existsStudyMemberByUserIdAndStudyInfoId(user.getId(), study.getId())) {
+                    log.warn(">>>> Github ID: {} {} <<<<", commit.username(), ExceptionMessage.STUDY_NOT_ACTIVE_MEMBER.getText());
+                    throw new MemberException(ExceptionMessage.STUDY_NOT_ACTIVE_MEMBER);
+                }
+
+                // 커밋, 투두 정보 업데이트
+                updateCommitAndTodoMappingStatus(user.getId(), study.getId(), todo, commit);
+
+                // 커밋 스터디장에게 알림처리
+                User studyLeader = userService.findUserByIdOrThrowException(study.getUserId());
+                eventPublisher.publishEvent(CommitRegisterEvent.builder()
+                        .isPushAlarmYn(studyLeader.isPushAlarmYn())
+                        .userId(studyLeader.getId())
+                        .name(user.getName())
+                        .studyInfoId(study.getId())
+                        .studyTopic(study.getTopic())
+                        .studyTodoTopic(todo.getTitle()));
+            }
         }
-
-        //  커밋, 투두 정보 업데이트
-        updateCommitAndTodoMappingStatus(user.getId(), study.getId(), todo, payload);
-
-        // 커밋 스터디장에게 알림처리
-        User studyLeader = userService.findUserByIdOrThrowException(study.getUserId());
-
-        eventPublisher.publishEvent(CommitRegisterEvent.builder()
-                .isPushAlarmYn(studyLeader.isPushAlarmYn())
-                .userId(studyLeader.getId())
-                .name(user.getName())
-                .studyInfoId(study.getId())
-                .studyTopic(study.getTopic())
-                .studyTodoTopic(todo.getTitle()));
     }
+
+    private Set<String> extractFolderNames(List<String>... fileLists) {
+        return Arrays.stream(fileLists)                         // Stream<List<String>>
+                .filter(Objects::nonNull)                       // null이 아닌 리스트만 필터링
+                .flatMap(List::stream)                          // Stream<String>
+                .filter(filePath -> filePath.contains("/"))     // "/"가 있는 경로만 필터링
+                .map(filePath -> filePath.substring(0, filePath.indexOf("/")))  // 폴더 이름 추출
+                .collect(Collectors.toSet());                   // Set<String>
+    }
+
 
     private User getUserByPayLoad(String githubId) {
         return userRepository.findByGithubId(githubId).orElseThrow(() -> {
@@ -100,16 +123,22 @@ public class WebhookService {
         });
     }
 
-    private void updateCommitAndTodoMappingStatus(Long userId, Long studyId, StudyTodo todo, WebhookPayload payload) {
+    private void updateCommitAndTodoMappingStatus(Long userId, Long studyId, StudyTodo todo, CommitPayload commit) {
 
-        // 지각 여부 체크
-        StudyTodoStatus updateStatus = payload.commitDate().isAfter(todo.getTodoDate()) ?
-                StudyTodoStatus.TODO_OVERDUE : StudyTodoStatus.TODO_COMPLETE;
-
-        // 투두 mapping 상태 업데이트
-        if (!studyTodoMappingRepository.updateByUserIdAndTodoId(userId, todo.getId(), updateStatus)) {
-            log.warn(">>>> Todo Id: {} {} <<<<", todo.getId(), ExceptionMessage.STUDY_TODO_MAPPING_NOT_FOUND);
+        // 해당하는 투두 매핑 정보가 없는 경우 예외가 발생한다.
+        StudyTodoMapping todoMapping = studyTodoMappingRepository.findByTodoIdAndUserId(todo.getId(), userId).orElseThrow(() -> {
+            log.warn(">>>> {} <<<<", ExceptionMessage.STUDY_TODO_MAPPING_NOT_FOUND.getText());
             throw new TodoException(ExceptionMessage.STUDY_TODO_MAPPING_NOT_FOUND);
+        });
+
+        // 아직 처리되지 않은 투두의 첫 커밋이거나 지각 처리됐던 투두에 재커밋한 경우
+        if (todoMapping.getStatus() == TODO_INCOMPLETE ||
+                todoMapping.getStatus() == TODO_OVERDUE) {
+
+            // 지각 여부 체크
+            StudyTodoStatus updateStatus = commit.commitDate().isAfter(todo.getTodoDate()) ? TODO_OVERDUE : TODO_COMPLETE;
+
+            todoMapping.updateTodoMappingStatus(updateStatus);
         }
 
         // 커밋 저장
@@ -117,9 +146,9 @@ public class WebhookService {
                 .userId(userId)
                 .studyInfoId(studyId)
                 .studyTodoId(todo.getId())
-                .commitSHA(payload.commitId())
-                .message(payload.message())
-                .commitDate(payload.commitDate())
+                .commitSHA(commit.commitId())
+                .message(commit.message())
+                .commitDate(commit.commitDate())
                 .status(CommitStatus.COMMIT_WAITING)
                 .build());
     }

--- a/backend/src/test/java/com/example/backend/domain/define/study/commit/StudyCommitFixture.java
+++ b/backend/src/test/java/com/example/backend/domain/define/study/commit/StudyCommitFixture.java
@@ -40,6 +40,19 @@ public class StudyCommitFixture {
                 .build();
     }
 
+    public static StudyCommit createStudyCommitWithDate(Long userId, Long studyInfoId, Long studyTodoId, String commitSHA, LocalDate date) {
+        return StudyCommit.builder()
+                .studyInfoId(studyInfoId)
+                .studyTodoId(studyTodoId)
+                .userId(userId)
+                .commitSHA(commitSHA)
+                .message("메세지")
+                .commitDate(date)
+                .status(COMMIT_WAITING)
+                .rejectionReason(null)
+                .build();
+    }
+
     // 중복되지 않는 랜덤 값을 생성하는 메서드
     private static int generateUniqueRandomValue(Set<Integer> usedValues) {
         int randomValue;

--- a/backend/src/test/java/com/example/backend/domain/define/study/todo/StudyTodoFixture.java
+++ b/backend/src/test/java/com/example/backend/domain/define/study/todo/StudyTodoFixture.java
@@ -52,6 +52,14 @@ public class StudyTodoFixture {
                 .build();
     }
 
+    // 테스트용  지각 상태의 studyTodoMapping 생성
+    public static StudyTodoMapping createOverdueStudyTodoMapping(Long todoId, Long userId) {
+        return StudyTodoMapping.builder()
+                .todoId(todoId)
+                .userId(userId)
+                .status(StudyTodoStatus.TODO_OVERDUE)
+                .build();
+    }
 
     // 테스트용 To do 등록
     public static StudyTodoRequest generateStudyTodoRequest() {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#542 

### Pull Request Type
- [ ]  새로운 기능 추가
- [x]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [x]  테스트 추가, 테스트 리팩토링
- [ ]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist
- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용
### 기존 웹훅 로직

1. push 이벤트 발생하면 등록된 웹훅으로 전송
2. 커밋 정보 받아와서 커밋, 투두 정보 업데이트
3. 스터디장에게 알림

### 수정된 웹훅 로직

1. push 이벤트 발생하면 등록된 웹훅으로 전송
2. 커밋 페이로드 리스트를 받는다. 각 페이로드에는 등록 파일 리스트가 들어있다.
    - 삭제의 경우는 고려하지 않았다.
3. 커밋 페이로드 리스트를 순회하면서 아래 과정을 반복한다.
    1. 페이로드 안 등록/수정 리스트의 파일 경로에서 투두 폴더 이름을 Set으로 추출한다.
    2. 폴더 이름 Set을 돌면서 투두, 사용자를 특정한 후 권한 검증을 거쳐 커밋, 투두 매핑 정보를 업데이트한다.
        - 이미 완료한 투두의 새로운 커밋이라도 투두 매핑 업데이트가 필요할 수 있다. (이전 커밋보다 푸시 시점은 늦어도 실제 커밋 시점이 빠를 수 있으므로)

### 추가된 테스트

- `지각했던_투두에_다시_커밋했을_때_커밋_시점이_마감일_전이라면_투두매핑_완료상태로_업데이트`
- `지각했던_투두에_다시_커밋했을_때_커밋_시점이_마감일_후라면_투두매핑_변경없음`
- `하나의_커밋에_여러개의_투두를_묶어서_푸시한_경우_해당하는_투두에_적용해야_한다`
    - 마음같아선 커밋 단위를 투두로 해달라고 하고 싶지만 “밀린 숙제 제출합니다” 처럼 묶어서 커밋하는 경우가 분명 있을 것 같네요
- `하나의_푸시에_여러개의_커밋리스트가_페이로드로_전송되어도_전부_처리되어야_한다`

### 리뷰 요구사항

웹훅 푸시 이벤트 중 commits가 비어있는 경우는 브랜치가 삭제되었을 때 발생하는 이벤트라고 하니 따로 웹훅 처리 API 호출해주지 않으셔도 될 것 같습니다!

현재 엔티티의 커밋 sha가 유니크 속성으로 지정되어 있는데 하나의 커밋에 여러 투두에 대한 파일이 들어있을 수 있으므로 투두마다 해당 커밋을 등록해주기 위해 커밋 sha 유니크 속성을 풀었습니다.

따로 커밋 sha가 유니크하다는 점을 이용한 로직은 찾지 못해서 일단 그렇게 진행했습니다..

추가로, 이 경우 커밋 상세 페이지에 접속했을 때 같은 커밋으로 묶인 다른 투두의 파일들까지 보인다는..

- 마음같아선 커밋 단위를 투두로 해달라고 하고 싶지만 “밀린 숙제 제출합니다” 처럼 묶어서 커밋하는 경우가 분명 있을 것 같네요

생각할 케이스가 많아서 어지럽네요 피드백 주세요~


