### PR TITLE
[BE] refactor(#557): 백엔드 호출 url 수정

### DIFF
--- a/webhooks/src/main/kotlin/site/gitudy/webhooks/infrastructure/gitudy/WebhookClient.kt
+++ b/webhooks/src/main/kotlin/site/gitudy/webhooks/infrastructure/gitudy/WebhookClient.kt
@@ -15,7 +15,7 @@ class WebhookClient(
 ) {
     private val log = logger<WebhookClient>()
     suspend fun saveWebhookCommit(request: WebhookCommitRequest) {
-        val response = WebClient.create("http://localhost:8080")
+        val response = WebClient.create("http://gitudy:8080")
             .post()
             .uri("/webhook/commit")
             .header("Authorization", "Bearer $serverToken")


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#557 

### Pull Request Type
- [ ]  새로운 기능 추가
- [x]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용

## 어떤 기능인가요?


webhooks에서 /webhook/commit 을 호출할 때 경로를 찾지 못하는 문제가 발생했습니다.

<img width="716" alt="image" src="https://github.com/user-attachments/assets/73498895-5194-42ff-8af4-92d98d1a3269">

없는 경로로 호출했을 때 발생하는 에러가 나타났습니다.

localhost로 지정해도 호스트 머신의 8080 포트로 인식하지 못하고 있는 것 같습니다.
같은 네트워크로 묶여있으므로 백엔드 컨테이너 이름을 명시적으로 적어서 시도해보겠습니다. 



