### PR TITLE
[BE] refactor(#559): 투두 폴더 생성 커밋까지 등록되는 문제 해결

### DIFF
--- a/backend/src/main/java/com/example/backend/auth/config/security/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/backend/auth/config/security/filter/JwtAuthenticationFilter.java
@@ -78,7 +78,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 subject = jwtService.extractSubject(accessToken);
                 // JWT 토큰 인증 로직 (JWT 검증 후 인증된 Authentication을 SecurityContext에 등록
                 authenticateUserWithJwtToken(subject, accessToken, request);
-                log.info(">>>> [ Jwt 토큰이 성공적으로 인증되었습니다. ] <<<<");
 
                 // JWT 토큰 인증을 마치면 다음 인증 필터로 이동
                 filterChain.doFilter(request, response);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#559 

### Pull Request Type
- [ ]  새로운 기능 추가
- [x]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [x]  테스트 추가, 테스트 리팩토링
- [ ]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist
- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용

- 투두 폴더 생성 커밋까지 등록되는 문제 해결
    - 투두 폴더 생성 커밋 구분 단계
        1. 페이로드의 커밋이 1개여야 한다.
        2. 그 1개의 커밋에 추가된 파일이 1개이면서 수정된 파일이 없어야 한다.
        3. 추가된 파일 1개가 .md의 확장자(마크다운 파일) 이어야 한다.

- JWT 인증 성공 로그 삭제


## 💬 리뷰 요구사항

JWT 인증 성공 로그가 너무 많이 찍혀서 로그를 보기 힘들어서 삭제했습니닷
(이제 인증 실패 시에만 실패 로그가 찍힙니다)

피드백 주세요~