### PR TITLE
[BE] refactor(#594): 비효율적인 todo 조회 쿼리 수정

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/define/study/todo/repository/StudyTodoRepositoryImpl.java
+++ b/backend/src/main/java/com/example/backend/domain/define/study/todo/repository/StudyTodoRepositoryImpl.java
@@ -1,22 +1,20 @@
 package com.example.backend.domain.define.study.todo.repository;
 
-import com.example.backend.domain.define.account.user.User;
 import com.example.backend.domain.define.study.commit.StudyCommit;
 import com.example.backend.domain.define.study.todo.info.StudyTodo;
 import com.example.backend.study.api.controller.todo.response.StudyTodoWithCommitsResponse;
 import com.example.backend.study.api.service.commit.response.CommitInfoResponse;
 import com.example.backend.study.api.service.user.UserService;
-import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.example.backend.domain.define.account.user.QUser.user;
 import static com.example.backend.domain.define.study.commit.QStudyCommit.studyCommit;
 import static com.example.backend.domain.define.study.todo.info.QStudyTodo.studyTodo;
 import static com.example.backend.domain.define.study.todo.mapping.QStudyTodoMapping.studyTodoMapping;
@@ -30,50 +28,42 @@ public class StudyTodoRepositoryImpl implements StudyTodoRepositoryCustom {
     @Override
     public List<StudyTodoWithCommitsResponse> findStudyTodoListByStudyInfoId_CursorPaging(Long studyInfoId, Long cursorIdx, Long limit) {
 
-        // StudyTodo 기본 정보만 가져오는 쿼리
-        JPAQuery<StudyTodo> todoQuery = queryFactory
+        // StudyTodo 조회
+        List<StudyTodo> todos = queryFactory
                 .selectFrom(studyTodo)
                 .where(studyTodo.studyInfoId.eq(studyInfoId))
-                .orderBy(studyTodo.id.desc());
-
-        // cursorIdx가 null이 아닐 때 해당 ID 이하의 데이터를 조회
-        if (cursorIdx != null) {
-            todoQuery = todoQuery.where(studyTodo.id.lt(cursorIdx));
-        }
-
-        // 정해진 limit만큼 데이터를 가져온다
-        List<StudyTodo> todos = todoQuery.limit(limit).fetch();
+                .where(cursorIdx != null ? studyTodo.id.lt(cursorIdx) : null)
+                .orderBy(studyTodo.id.desc())
+                .limit(limit)
+                .fetch();
 
         // StudyTodo의 ID 리스트를 가져온다
         List<Long> todoIds = todos.stream().map(StudyTodo::getId).collect(Collectors.toList());
 
-        // StudyCommit 리스트를 가져오는 쿼리
-        List<StudyCommit> commits = queryFactory
-                .selectFrom(studyCommit)
+        // StudyCommit 리스트 조회 (User 정보 포함)
+        List<Tuple> commitResults = queryFactory
+                .select(studyCommit, user.name, user.profileImageUrl)
+                .from(studyCommit)
+                .join(user).on(user.id.eq(studyCommit.userId))
                 .where(studyCommit.studyTodoId.in(todoIds))
                 .fetch();
 
         // StudyCommit을 StudyTodo ID로 그룹화
-        Map<Long, List<CommitInfoResponse>> commitMap = commits.stream()
-                .collect(Collectors.groupingBy(
-                        StudyCommit::getStudyTodoId,
-                        Collectors.mapping(
-                                commit -> {
-                                    // 사용자 이름 조회
-                                    User user = userService.findUserByIdOrThrowException(commit.getUserId());
-                                    String name = user.getName();
-                                    String profileImageUrl = user.getProfileImageUrl();
-                                    return CommitInfoResponse.of(commit, name, profileImageUrl);
-                                },
-                                Collectors.toList())
-                ));
+        Map<Long, List<CommitInfoResponse>> commitMap = new HashMap<>();
+
+        for (Tuple tuple : commitResults) {
+            StudyCommit commit = tuple.get(studyCommit);
+            String username = tuple.get(user.name);
+            String profileImageUrl = tuple.get(user.profileImageUrl);
+
+            commitMap.computeIfAbsent(commit.getStudyTodoId(), k -> new ArrayList<>())
+                    .add(CommitInfoResponse.of(commit, username, profileImageUrl));
+        }
 
         // StudyTodo와 커밋 리스트를 조합하여 StudyTodoWithCommitsResponse 리스트를 생성
-        List<StudyTodoWithCommitsResponse> responses = todos.stream()
-                .map(todo -> StudyTodoWithCommitsResponse.of(todo, commitMap.getOrDefault(todo.getId(), List.of())))
+        return todos.stream()
+                .map(todo -> StudyTodoWithCommitsResponse.of(todo, commitMap.getOrDefault(todo.getId(), new ArrayList<>())))
                 .collect(Collectors.toList());
-
-        return responses;
     }
 
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#594 

### Pull Request Type
- [ ]  새로운 기능 추가
- [x]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist
- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용

쿼리 인덱스 테스트 도중 Todo 리스트 조회 시 엄청난 양의 쿼리가 출력되는 것을 확인했다.

**Todo 리스트 조회 로직은 다음과 같다**

1. Todo 리스트 조회
2. Todo에 해당하는 Commit 조회
3. Commit 작성자 User 조회

10개의 Commit이 있는 Todo 5개를 조회하면 발생하는 쿼리 수는 다음과 같다.

- Todo 리스트 조회 1개
- Commit 리스트 조회 1개
- Commit 마다 User 조회 50개 (5*10)

총 52개의 쿼리가 발생한다;;

처음에는 User 정보까지 조회하진 않았는데 중간에 User 정보까지 필요하게 되어 추가했을 때 실수했던 것 같다. (아마 지피티 그대로 옮긴듯^)

**수정 후**

<img width="429" alt="image" src="https://github.com/user-attachments/assets/5f0d69ad-3e0e-4fa0-81a9-d18545a765cf">
<img width="429" alt="image" src="https://github.com/user-attachments/assets/3d3f018f-74ab-4903-80b2-09ff735adaf6">

- Todo 리스트 조회 1개
- Commit + User 리스트 조회 1개

2개의 쿼리만 발생한다.

## 💬 리뷰 요구사항

피드백 주세욧
