### PR TITLE
[BE] feat(#609): 레디스 데이터 파티셔닝

### DIFF
--- a/backend/src/main/java/com/example/backend/auth/api/service/rank/RankingService.java
+++ b/backend/src/main/java/com/example/backend/auth/api/service/rank/RankingService.java
@@ -10,8 +10,9 @@ import com.example.backend.domain.define.study.info.StudyInfo;
 import com.example.backend.domain.define.study.info.constant.StudyStatus;
 import com.example.backend.domain.define.study.info.repository.StudyInfoRepository;
 import jakarta.annotation.PostConstruct;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
@@ -21,15 +22,21 @@ import java.util.List;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class RankingService {
 
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, Object> redisTemplateDb1;
     private final UserRepository userRepository;
     private final StudyInfoRepository studyInfoRepository;
     private static final String USER_RANKING_KEY = "user_ranking";
     private static final String STUDY_RANKING_KEY = "study_ranking";
+
+    @Autowired
+    public RankingService(@Qualifier("redisTemplateDb1") RedisTemplate<String, Object> redisTemplateDb1, UserRepository userRepository, StudyInfoRepository studyInfoRepository) {
+        this.redisTemplateDb1 = redisTemplateDb1;
+        this.userRepository = userRepository;
+        this.studyInfoRepository = studyInfoRepository;
+    }
 
     @PostConstruct
     public void init() {
@@ -40,19 +47,19 @@ public class RankingService {
 
     // 사용자 점수를 처음으로 Redis Sorted Set에 저장
     public void saveUserScore(Long userId, double score) {
-        ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
+        ZSetOperations<String, Object> zSetOps = redisTemplateDb1.opsForZSet();
         zSetOps.add(USER_RANKING_KEY, userId, score);
     }
 
     // 사용자 점수 증/감 업데이트
     public void updateUserScore(Long userId, double score) {
-        ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
+        ZSetOperations<String, Object> zSetOps = redisTemplateDb1.opsForZSet();
         zSetOps.incrementScore(USER_RANKING_KEY, userId, score);
     }
 
     // 특정 사용자의 랭킹 조회
     public UserRankingResponse getUserRankings(User user) {
-        ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
+        ZSetOperations<String, Object> zSetOps = redisTemplateDb1.opsForZSet();
         Double score = zSetOps.score(USER_RANKING_KEY, user.getId());
         if (score == null) {
             score = (double) user.getScore();
@@ -70,13 +77,13 @@ public class RankingService {
 
     // 유저 점수 삭제
     public void deleteUserScore(Long userId) {
-        ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
+        ZSetOperations<String, Object> zSetOps = redisTemplateDb1.opsForZSet();
         zSetOps.remove(USER_RANKING_KEY, userId);
     }
 
     // 어플리케이션 로드 시점에 Cache Warming 작업
     public void updateUserRanking() {
-        ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
+        ZSetOperations<String, Object> zSetOps = redisTemplateDb1.opsForZSet();
         // USER 역할인 사용자만 필터링하여 랭킹에 추가
         List<User> users = userRepository.findAll();
         for (User user : users) {
@@ -88,7 +95,7 @@ public class RankingService {
 
     // 마찬가지로 로드 시점에 Cache Warming
     public void updateStudyRanking() {
-        ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
+        ZSetOperations<String, Object> zSetOps = redisTemplateDb1.opsForZSet();
         List<StudyInfo> studyInfos = studyInfoRepository.findAll();
 
         // STUDY_DELETED 상태를 가진 스터디 제외
@@ -104,20 +111,20 @@ public class RankingService {
 
     // 스터디 점수 증/감 업데이트
     public void updateStudyScore(Long studyInfoId, double score) {
-        ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
+        ZSetOperations<String, Object> zSetOps = redisTemplateDb1.opsForZSet();
         zSetOps.incrementScore(STUDY_RANKING_KEY, studyInfoId, score);
     }
 
     // 스터디 점수를 처음으로 Redis Sorted Set에 저장
     public void saveStudyScore(Long studyInfoId, double score) {
-        ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
+        ZSetOperations<String, Object> zSetOps = redisTemplateDb1.opsForZSet();
         zSetOps.add(STUDY_RANKING_KEY, studyInfoId, score);
     }
 
     // 특정 스터디의 랭킹 조회
     public StudyRankingResponse getStudyRankings(StudyInfo studyInfo) {
 
-        ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
+        ZSetOperations<String, Object> zSetOps = redisTemplateDb1.opsForZSet();
         Double score = zSetOps.score(STUDY_RANKING_KEY, studyInfo.getId());
         if (score == null) {
             score = (double) studyInfo.getScore();
@@ -136,7 +143,7 @@ public class RankingService {
 
     // 스터디 점수 삭제
     public void deleteStudyScore(Long studyInfoId) {
-        ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
+        ZSetOperations<String, Object> zSetOps = redisTemplateDb1.opsForZSet();
         zSetOps.remove(STUDY_RANKING_KEY, studyInfoId);
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/config/RankRedisConfig.java
+++ b/backend/src/main/java/com/example/backend/domain/config/RankRedisConfig.java
@@ -1,18 +1,18 @@
 package com.example.backend.domain.config;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-@EnableRedisRepositories
-public class RedisConfig {
+public class RankRedisConfig {
 
     @Value("${spring.data.redis.host}")
     private String host;
@@ -20,20 +20,25 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int port;
 
-    // Bean으로 등록해 Redis 연결 - Lettuce 사용
+
     @Bean
-    public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(host, port);
+    public RedisConnectionFactory redisConnectionFactoryDb1() {
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(host, port);
+        factory.setDatabase(1);  // DB1 사용
+        return factory;
     }
 
-    // Sorted Set 사용하기 위한 Template, Operations
     @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
+    public RedisTemplate<String, Object> redisTemplateDb1() {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
-        template.setConnectionFactory(redisConnectionFactory());
+        template.setConnectionFactory(redisConnectionFactoryDb1());
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         return template;
     }
 
+    @Bean
+    public ZSetOperations<String, Object> zSetOperations(@Qualifier("redisTemplateDb1") RedisTemplate<String, Object> redisTemplateDb1) {
+        return redisTemplateDb1.opsForZSet();
+    }
 }

--- a/backend/src/test/java/com/example/backend/auth/api/service/rank/RankingServiceTest.java
+++ b/backend/src/test/java/com/example/backend/auth/api/service/rank/RankingServiceTest.java
@@ -28,7 +28,7 @@ public class RankingServiceTest extends MockTestConfig {
     private ZSetOperations<String, Object> zSetOperations;
 
     @Autowired
-    private RedisTemplate<String, Object> redisTemplate;
+    private RedisTemplate<String, Object> redisTemplateDb1;
 
     @Autowired
     private StudyInfoRepository studyInfoRepository;
@@ -42,14 +42,14 @@ public class RankingServiceTest extends MockTestConfig {
 
     @BeforeEach
     void setUp() {
-        //   when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+        //   when(redisTemplateDb1.opsForZSet()).thenReturn(zSetOperations);
     }
 
     @AfterEach
     void tearDown() {
         userRepository.deleteAllInBatch();
-        redisTemplate.delete(USER_RANKING_KEY);
-        redisTemplate.delete(STUDY_RANKING_KEY);
+        redisTemplateDb1.delete(USER_RANKING_KEY);
+        redisTemplateDb1.delete(STUDY_RANKING_KEY);
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#609 

### Pull Request Type

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  코드 리팩토링
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [x]  테스트 추가, 테스트 리팩토링
- [ ]  코드에 영향을 주지 않는 변경사항
    - 오타 수정, 문서 수정, 변수명 변경, 주석 추가 및 수정

### Pull Request Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  변경 사항에 대한 테스트를 모두 통과했나요?
- [x]  코드 정렬은 적용했나요?
- [x]  새로운 branch에 작업 후 dev로 PR을 요청했나요?

## 📝 작업 내용

현재 레디스에사용하는 인증토큰, 깃허브토큰, 기기fcm토큰, 랭킹 등을
인스턴스 db0, db1, db2, db3... 로 분리한다.

## 💬 리뷰 요구사항

토큰별로 분리하려 시도했지만 redisTemplate으로 저장하지 않는 JPA CrudRepository 상속받는 친구들은 db0으로 저장되도록 고정되어 있다네요 ㅠㅠ 그래서 랭킹만 분리할 수 있었슴다, ;-;

![image](https://github.com/user-attachments/assets/83879a35-b78d-42d1-b097-b7ef7e4c8b0e)




